### PR TITLE
Replace bitflags with custom Access* types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ exclude = [".gitignore"]
 readme = "README.md"
 
 [dependencies]
-bitflags = "1.2"
 libc = "0.2"
 
 [dev-dependencies]

--- a/src/access/fs.rs
+++ b/src/access/fs.rs
@@ -1,0 +1,132 @@
+use super::*;
+use crate::uapi;
+
+#[derive(Debug, Copy, Clone)]
+#[repr(u64)]
+pub enum AccessFs {
+    Execute = uapi::LANDLOCK_ACCESS_FS_EXECUTE as u64,
+    WriteFile = uapi::LANDLOCK_ACCESS_FS_WRITE_FILE as u64,
+    ReadFile = uapi::LANDLOCK_ACCESS_FS_READ_FILE as u64,
+    ReadDir = uapi::LANDLOCK_ACCESS_FS_READ_DIR as u64,
+    RemoveDir = uapi::LANDLOCK_ACCESS_FS_REMOVE_DIR as u64,
+    RemoveFile = uapi::LANDLOCK_ACCESS_FS_REMOVE_FILE as u64,
+    MakeChar = uapi::LANDLOCK_ACCESS_FS_MAKE_CHAR as u64,
+    MakeDir = uapi::LANDLOCK_ACCESS_FS_MAKE_DIR as u64,
+    MakeReg = uapi::LANDLOCK_ACCESS_FS_MAKE_REG as u64,
+    MakeSock = uapi::LANDLOCK_ACCESS_FS_MAKE_SOCK as u64,
+    MakeFifo = uapi::LANDLOCK_ACCESS_FS_MAKE_FIFO as u64,
+    MakeBlock = uapi::LANDLOCK_ACCESS_FS_MAKE_BLOCK as u64,
+    MakeSym = uapi::LANDLOCK_ACCESS_FS_MAKE_SYM as u64,
+}
+
+// It would be nice to have const BitOr implementations:
+// https://github.com/rust-lang/rfcs/blob/master/text/0911-const-fn.md
+impl AccessFs {
+    /// Returns `ReadFile | ReadDir`.
+    pub fn read() -> AccessRights<Self> {
+        AccessFs::ReadFile | AccessFs::ReadDir
+    }
+
+    /// Returns `MakeChar | MakeDir | MakeReg | MakeSock | MakeFifo | MakeBlock | MakeSym`.
+    pub fn make() -> AccessRights<Self> {
+        AccessFs::MakeChar
+            | AccessFs::MakeDir
+            | AccessFs::MakeReg
+            | AccessFs::MakeSock
+            | AccessFs::MakeFifo
+            | AccessFs::MakeBlock
+            | AccessFs::MakeSym
+    }
+
+    /// Returns `RemoveDir | RemoveFile`.
+    pub fn remove() -> AccessRights<Self> {
+        AccessFs::RemoveDir | AccessFs::RemoveFile
+    }
+
+    /// Returns `Execute | WriteFile | ReadFile | ReadDir | RemoveDir | RemoveFile | MakeChar |
+    /// MakeDir | MakeReg | MakeSock | MakeFifo | MakeBlock | MakeSym`.
+    pub fn group1() -> AccessRights<Self> {
+        AccessFs::Execute
+            | AccessFs::WriteFile
+            | AccessFs::ReadFile
+            | AccessFs::ReadDir
+            | AccessFs::RemoveDir
+            | AccessFs::RemoveFile
+            | AccessFs::MakeChar
+            | AccessFs::MakeDir
+            | AccessFs::MakeReg
+            | AccessFs::MakeSock
+            | AccessFs::MakeFifo
+            | AccessFs::MakeBlock
+            | AccessFs::MakeSym
+    }
+}
+
+impl AccessFlags for AccessFs {
+    fn get_flags(self) -> u64 {
+        self as u64
+    }
+}
+
+impl AccessRights<AccessFs> {
+    // This will stay compatible because it only removes access bits.
+    /// Masks access rights that are not compatible with files, i.e. only keeps `Execute |
+    /// WriteFile | ReadFile`.
+    pub fn mask_dir_accesses(mut self) -> Self {
+        self.flags &=
+            AccessFs::Execute as u64 | AccessFs::WriteFile as u64 | AccessFs::ReadFile as u64;
+        self
+    }
+}
+
+impl AccessFlagsInner for AccessFs {}
+
+pub trait AccessFlagsFs: AccessFlags {}
+
+impl AccessFlagsFs for AccessFs {}
+
+impl AccessFlagsFs for AccessRights<AccessFs> {}
+
+impl<T> BitOr<T> for AccessFs
+where
+    T: AccessFlagsFs,
+{
+    type Output = AccessRights<Self>;
+
+    fn bitor(self, rhs: T) -> Self::Output {
+        AccessRights {
+            flags: self as u64 | rhs.get_flags(),
+            _sub: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_accesses<T>(set: T)
+    where
+        T: Into<AccessRights<AccessFs>>,
+    {
+        println!("access set: {:?}", set.into());
+    }
+
+    #[test]
+    fn access_fs() {
+        let _read = AccessFs::read();
+        //let read_set_set: AccessRights<AccessRights<AccessFs>> = _read.into();
+
+        let exec = AccessFs::Execute;
+        let _exec_set: AccessRights<AccessFs> = exec.into();
+
+        let mut set1 = exec | AccessFs::WriteFile | AccessFs::ReadFile;
+        get_accesses(set1);
+        get_accesses(AccessFs::Execute);
+
+        let set2 = AccessFs::WriteFile | set1;
+        set1 |= AccessFs::MakeChar;
+        set1 = set2 | set1;
+        set1 |= set2;
+    }
+}

--- a/src/access/mod.rs
+++ b/src/access/mod.rs
@@ -1,0 +1,86 @@
+pub use fs::*;
+use std::marker::PhantomData;
+use std::ops::{BitOr, BitOrAssign};
+
+mod fs;
+
+#[cfg(test)]
+mod net;
+
+pub trait AccessFlags: BitOr + Sized {
+    fn get_flags(self) -> u64;
+}
+
+pub trait AccessFlagsInner: AccessFlags + BitOr<AccessRights<Self>> + Sized {}
+
+#[derive(Debug, Copy, Clone)]
+pub struct AccessRights<T>
+where
+    T: AccessFlagsInner,
+{
+    flags: u64,
+    _sub: PhantomData<T>,
+}
+
+impl<T> AccessFlags for AccessRights<T>
+where
+    T: AccessFlagsInner,
+{
+    fn get_flags(self) -> u64 {
+        self.flags
+    }
+}
+
+impl<T> From<T> for AccessRights<T>
+where
+    T: AccessFlagsInner,
+{
+    fn from(access: T) -> Self {
+        AccessRights {
+            flags: access.get_flags(),
+            _sub: PhantomData,
+        }
+    }
+}
+
+impl<T> BitOr for AccessRights<T>
+where
+    T: AccessFlagsInner,
+{
+    type Output = Self;
+
+    fn bitor(mut self, rhs: Self) -> Self::Output {
+        self.flags |= rhs.get_flags();
+        self
+    }
+}
+
+impl<T> BitOr<T> for AccessRights<T>
+where
+    T: AccessFlagsInner,
+{
+    type Output = Self;
+
+    fn bitor(mut self, rhs: T) -> Self::Output {
+        self.flags |= rhs.get_flags();
+        self
+    }
+}
+
+impl<T> BitOrAssign for AccessRights<T>
+where
+    T: AccessFlagsInner,
+{
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.flags |= rhs.get_flags();
+    }
+}
+
+impl<T> BitOrAssign<T> for AccessRights<T>
+where
+    T: AccessFlagsInner,
+{
+    fn bitor_assign(&mut self, rhs: T) {
+        self.flags |= rhs.get_flags();
+    }
+}

--- a/src/access/net.rs
+++ b/src/access/net.rs
@@ -1,0 +1,50 @@
+// TEST ONLY
+
+use super::*;
+
+#[derive(Debug, Copy, Clone)]
+#[repr(u64)]
+pub enum AccessNet {
+    Connect = 1,
+}
+
+impl AccessFlags for AccessNet {
+    fn get_flags(self) -> u64 {
+        self as u64
+    }
+}
+
+impl AccessFlagsInner for AccessNet {}
+
+pub trait AccessFlagsNet: AccessFlags {}
+
+impl AccessFlagsNet for AccessNet {}
+
+impl AccessFlagsNet for AccessRights<AccessNet> {}
+
+impl<T> BitOr<T> for AccessNet
+where
+    T: AccessFlagsNet,
+{
+    type Output = AccessRights<Self>;
+
+    fn bitor(self, rhs: T) -> Self::Output {
+        AccessRights {
+            flags: self as u64 | rhs.get_flags(),
+            _sub: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn access_net() {
+        let connect = AccessNet::Connect;
+        let _connect_set: AccessRights<AccessNet> = connect.into();
+
+        //let _connect_set_wrong_type: AccessRights<AccessFs> = connect.into();
+    }
+}


### PR DESCRIPTION
This is the continuation of #3 

The bitflags implementation makes it possible for developers to set
arbitrary and potentially unknown access rights without being noticed.

Replace bitflags with a custom AccessFs and AccessRighs<AccessFs> types,
and AccessFlags, AccessFlagsInner and AccessFlagsFs traits to get a
deterministic API and avoid type confusion issues.  Add a set of
pre-defined filesystem access rights (read, make, remove and group1) to
make it easier to use these rights.  This new types will also enable to
add runtime compatibility checks.

Because it is not possible to implement const trait yet, we can't set
const access right.  See
https://github.com/rust-lang/rfcs/blob/master/text/0911-const-fn.md

Add fake network access rights for test purpose, to check that this
approach is generic enough and guard against type confusion issues for
future access right types.