### PR TITLE
Add high-level errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ readme = "README.md"
 [dependencies]
 enumflags2 = "0.7"
 libc = "0.2"
+thiserror = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -54,7 +54,7 @@ impl RulesetCreatedExt for RulesetCreated {
                 let path = OsStr::from_bytes(path);
                 Ok(ruleset
                     .add_rule(
-                        PathBeneath::new(&PathFd::new(&path).map_err(|e| {
+                        PathBeneath::new(PathFd::new(&path).map_err(|e| {
                             anyhow!("Failed to open \"{}\": {}", path.to_string_lossy(), e)
                         })?)
                         .allow_access(access),

--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail};
 use landlock::{
-    make_bitflags, AccessFs, BitFlags, PathBeneath, PathFd, Ruleset, RulesetCreated, RulesetStatus,
-    ABI,
+    make_bitflags, Access, AccessFs, BitFlags, PathBeneath, PathFd, Ruleset, RulesetCreated,
+    RulesetStatus, ABI,
 };
 use std::env;
 use std::ffi::OsStr;
@@ -103,7 +103,7 @@ fn main() -> Result<(), anyhow::Error> {
     })?;
 
     let status = Ruleset::new()
-        .handle_fs(ABI::V1)?
+        .handle_access(AccessFs::from_all(ABI::V1))?
         .create()?
         .populate_with_env(ENV_FS_RO_NAME, ACCESS_FS_ROUGHLY_READ)?
         .populate_with_env(

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -148,9 +148,8 @@ pub struct Compatibility {
     pub(crate) state: CompatState,
 }
 
-impl Compatibility {
-    pub fn new() -> Compatibility {
-        let abi = ABI::new_current();
+impl From<ABI> for Compatibility {
+    fn from(abi: ABI) -> Self {
         Compatibility {
             abi: abi,
             is_best_effort: true,
@@ -160,6 +159,12 @@ impl Compatibility {
                 _ => CompatState::Start,
             },
         }
+    }
+}
+
+impl Compatibility {
+    pub fn new() -> Compatibility {
+        ABI::new_current().into()
     }
 }
 
@@ -253,11 +258,7 @@ where
 
 #[test]
 fn compat_bit_flags() {
-    let mut compat = Compatibility {
-        abi: ABI::V1,
-        is_best_effort: true,
-        state: CompatState::Start,
-    };
+    let mut compat = ABI::V1.into();
 
     let ro_access = make_bitflags!(AccessFs::{Execute | ReadFile | ReadDir});
     assert_eq!(ro_access, ro_access.try_compat(&mut compat).unwrap());

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -192,7 +192,6 @@ fn bit_flags_full_negation() {
 impl<T> TryCompat<T> for BitFlags<T>
 where
     T: Access,
-    BitFlags<T>: From<ABI>,
 {
     fn try_compat(self, compat: &mut Compatibility) -> Result<Self, CompatError<T>> {
         let (state, new_access) = if self.is_empty() {
@@ -207,7 +206,7 @@ where
             }
             .into());
         } else {
-            let compat_bits = self & Self::from(compat.abi);
+            let compat_bits = self & T::from_all(compat.abi);
             if compat_bits.is_empty() {
                 if compat.is_best_effort {
                     // TODO: This creates an empty access-right and could be an issue with

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,5 +1,4 @@
-use crate::{uapi, AccessError, BitFlags, CompatError};
-use enumflags2::BitFlag;
+use crate::{uapi, Access, AccessError, BitFlags, CompatError};
 
 #[cfg(test)]
 use crate::{make_bitflags, AccessFs};
@@ -170,13 +169,13 @@ pub trait TryCompat<T> {
     fn try_compat(self, compat: &mut Compatibility) -> Result<Self, CompatError<T>>
     where
         Self: Sized,
-        T: BitFlag;
+        T: Access;
 }
 
 // Creates an illegal/overflowed BitFlags<T> with all its bits toggled, including undefined ones.
 fn full_negation<T>(flags: BitFlags<T>) -> BitFlags<T>
 where
-    T: BitFlag,
+    T: Access,
 {
     unsafe { BitFlags::<T>::from_bits_unchecked(!flags.bits()) }
 }
@@ -192,7 +191,7 @@ fn bit_flags_full_negation() {
 
 impl<T> TryCompat<T> for BitFlags<T>
 where
-    T: BitFlag,
+    T: Access,
     BitFlags<T>: From<ABI>,
 {
     fn try_compat(self, compat: &mut Compatibility) -> Result<Self, CompatError<T>> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,7 +18,7 @@ where
     #[error(transparent)]
     AddRule(#[from] AddRuleError<T>),
     #[error(transparent)]
-    AddRules(#[from] AddRulesError<T, E>),
+    AddRules(#[from] AddRulesError<E>),
     #[error(transparent)]
     RestrictSelf(#[from] RestrictSelfError),
     #[error(transparent)]
@@ -77,17 +77,28 @@ where
     Compat(#[from] CompatError<T>),
 }
 
+// Generically implement for all the access implementations rather than for the cases listed in
+// AddRulesError (with #[from]).
+impl<A, E> From<AddRuleError<A>> for AddRulesError<E>
+where
+    A: Access,
+    E: std::error::Error,
+{
+    fn from(error: AddRuleError<A>) -> Self {
+        A::into_add_rules_error(error)
+    }
+}
+
 /// Identifies errors when adding rules to a ruleset thanks to an iterator returning
 /// Result<Rule, E> items.
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum AddRulesError<T, E>
+pub enum AddRulesError<E>
 where
-    T: Access,
     E: std::error::Error,
 {
     #[error(transparent)]
-    AddRule(#[from] AddRuleError<T>),
+    AddRuleFs(AddRuleError<AccessFs>),
     #[error(transparent)]
     Iter(E),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,4 @@
-use crate::{AccessFs, BitFlags};
-use enumflags2::BitFlag;
+use crate::{Access, AccessFs, BitFlags};
 use std::io;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -9,7 +8,7 @@ use thiserror::Error;
 #[non_exhaustive]
 pub enum RulesetError<T>
 where
-    T: BitFlag,
+    T: Access,
 {
     #[error(transparent)]
     HandleFs(#[from] HandleFsError),
@@ -29,18 +28,6 @@ fn ruleset_error_breaking_change() {
 
     // Generics are part of the API and modifying them can lead to a breaking change.
     let _: RulesetError<AccessFs> = RulesetError::HandleFs(HandleFsError::Compat(
-        CompatError::Access(AccessError::Empty),
-    ));
-
-    // FIXME: This should not be possible.
-    use enumflags2::bitflags;
-    #[bitflags]
-    #[repr(u64)]
-    #[derive(Copy, Clone)]
-    enum WrongAccess {
-        Foo,
-    }
-    let _: RulesetError<WrongAccess> = RulesetError::HandleFs(HandleFsError::Compat(
         CompatError::Access(AccessError::Empty),
     ));
 }
@@ -68,7 +55,7 @@ pub enum CreateRulesetError {
 #[non_exhaustive]
 pub enum AddRuleError<T>
 where
-    T: BitFlag,
+    T: Access,
 {
     /// The `landlock_add_rule()` system call failed.
     #[error("failed to add a rule: {source}")]
@@ -88,7 +75,7 @@ where
 #[non_exhaustive]
 pub enum CompatError<T>
 where
-    T: BitFlag,
+    T: Access,
 {
     #[error(transparent)]
     PathBeneath(#[from] PathBeneathError),
@@ -118,7 +105,7 @@ pub enum PathBeneathError {
 // Exhaustive enum
 pub enum AccessError<T>
 where
-    T: BitFlag,
+    T: Access,
 {
     /// The access-rights set is empty, which doesn't make sense and would be rejected by the
     /// kernel.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,118 @@
+use crate::{AccessFs, BitFlags};
+use enumflags2::BitFlag;
+use std::io;
+use thiserror::Error;
+
+/// Identifies errors when updating the ruleset's handled file system access-rights.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum HandleFsError {
+    #[error(transparent)]
+    Compat(#[from] CompatError<AccessFs>),
+}
+
+/// Identifies errors when creating a ruleset.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CreateRulesetError {
+    /// The `landlock_create_ruleset()` system call failed.
+    #[error("failed to create a ruleset: {source}")]
+    #[non_exhaustive]
+    CreateRulesetCall { source: io::Error },
+}
+
+/// Identifies errors when adding a rule to a ruleset.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AddRuleError<T>
+where
+    T: BitFlag,
+{
+    /// The `landlock_add_rule()` system call failed.
+    #[error("failed to add a rule: {source}")]
+    #[non_exhaustive]
+    AddRuleCall { source: io::Error },
+    /// The rule's access-rights are not all handled by the (requested) ruleset access-rights.
+    #[error("access-rights not handled by the ruleset: {incompatible:?}")]
+    UnhandledAccess {
+        access: BitFlags<T>,
+        incompatible: BitFlags<T>,
+    },
+    #[error(transparent)]
+    Compat(#[from] CompatError<T>),
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CompatError<T>
+where
+    T: BitFlag,
+{
+    #[error(transparent)]
+    PathBeneath(#[from] PathBeneathError),
+    #[error(transparent)]
+    Access(#[from] AccessError<T>),
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PathBeneathError {
+    /// To check that access-rights are consistent with a file descriptor, a call to
+    /// `RulesetCreated::add_rule()` looks at the file type with an `fstat()` system call.
+    #[error("failed to check file descriptor type: {source}")]
+    #[non_exhaustive]
+    StatCall { source: io::Error },
+    /// This error is returned by `RulesetCreated::add_rule() `if the related PathBeneath object is
+    /// not set to best-effort, and if its allowed access-rights contain directory-only ones
+    /// whereas the file descriptor doesn't point to a directory.
+    #[error("incompatible directory-only access-rights: {incompatible:?}")]
+    DirectoryAccess {
+        access: BitFlags<AccessFs>,
+        incompatible: BitFlags<AccessFs>,
+    },
+}
+
+#[derive(Debug, Error)]
+// Exhaustive enum
+pub enum AccessError<T>
+where
+    T: BitFlag,
+{
+    /// The access-rights set is empty, which doesn't make sense and would be rejected by the
+    /// kernel.
+    #[error("empty access-right")]
+    Empty,
+    /// The access-rights set was forged with the unsafe `BitFlags::from_bits_unchecked()` and it
+    /// contains unknown bits.
+    #[error("unknown access-rights (at build time): {unknown:?}")]
+    Unknown {
+        access: BitFlags<T>,
+        unknown: BitFlags<T>,
+    },
+    /// The best-effort approach was (deliberately) disabled and the requested access-rights are
+    /// fully incompatible with the running kernel.
+    #[error("fully incompatible access-rights: {access:?}")]
+    Incompatible { access: BitFlags<T> },
+    /// The best-effort approach was (deliberately) disabled and the requested access-rights are
+    /// partially incompatible with the running kernel.
+    #[error("partially incompatible access-rights: {incompatible:?}")]
+    PartiallyCompatible {
+        access: BitFlags<T>,
+        incompatible: BitFlags<T>,
+    },
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RestrictSelfError {
+    /// The `prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)` system call failed.
+    #[error(
+        "failed to use PR_SET_NO_NEW_PRIVS whereas it should be supported by the running kernel: {source}"
+    )]
+    #[non_exhaustive]
+    UnsupportedNoNewPrivs { source: io::Error },
+    /// The `landlock_restrict_self() `system call failed.
+    #[error("failed to restrict the calling thread: {source}")]
+    #[non_exhaustive]
+    RestrictSelfCall { source: io::Error },
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,7 @@ where
     T: Access,
 {
     #[error(transparent)]
-    HandleFs(#[from] HandleFsError),
+    HandleAccess(#[from] HandleAccessError<T>),
     #[error(transparent)]
     CreateRuleset(#[from] CreateRulesetError),
     #[error(transparent)]
@@ -27,17 +27,20 @@ fn ruleset_error_breaking_change() {
     use crate::*;
 
     // Generics are part of the API and modifying them can lead to a breaking change.
-    let _: RulesetError<AccessFs> = RulesetError::HandleFs(HandleFsError::Compat(
+    let _: RulesetError<AccessFs> = RulesetError::HandleAccess(HandleAccessError::Compat(
         CompatError::Access(AccessError::Empty),
     ));
 }
 
-/// Identifies errors when updating the ruleset's handled file system access-rights.
+/// Identifies errors when updating the ruleset's handled access-rights.
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum HandleFsError {
+pub enum HandleAccessError<T>
+where
+    T: Access,
+{
     #[error(transparent)]
-    Compat(#[from] CompatError<AccessFs>),
+    Compat(#[from] CompatError<T>),
 }
 
 /// Identifies errors when creating a ruleset.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -106,11 +106,9 @@ where
 #[non_exhaustive]
 pub enum RestrictSelfError {
     /// The `prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)` system call failed.
-    #[error(
-        "failed to use PR_SET_NO_NEW_PRIVS whereas it should be supported by the running kernel: {source}"
-    )]
+    #[error("failed to set no_new_privs: {source}")]
     #[non_exhaustive]
-    UnsupportedNoNewPrivs { source: io::Error },
+    SetNoNewPrivsCall { source: io::Error },
     /// The `landlock_restrict_self() `system call failed.
     #[error("failed to restrict the calling thread: {source}")]
     #[non_exhaustive]

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,7 +1,7 @@
 use crate::{
-    uapi, Access, AddRuleError, CompatError, Compatibility, Compatible, HandleAccessError,
-    PathBeneathError, PathFdError, PrivateAccess, PrivateRule, Rule, Ruleset, RulesetCreated,
-    TryCompat, ABI,
+    uapi, Access, AddRuleError, AddRulesError, CompatError, Compatibility, Compatible,
+    HandleAccessError, PathBeneathError, PathFdError, PrivateAccess, PrivateRule, Rule, Ruleset,
+    RulesetCreated, TryCompat, ABI,
 };
 use enumflags2::{bitflags, make_bitflags, BitFlags};
 use std::fs::{File, OpenOptions};
@@ -70,6 +70,13 @@ impl PrivateAccess for AccessFs {
             .requested_handled_fs
             .try_compat(&mut ruleset.compat)?;
         Ok(ruleset)
+    }
+
+    fn into_add_rules_error<E>(error: AddRuleError<Self>) -> AddRulesError<E>
+    where
+        E: std::error::Error,
+    {
+        AddRulesError::AddRuleFs(error)
     }
 }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -205,6 +205,15 @@ fn path_beneath_try_compat() {
 // of doing it generically.
 impl Rule<AccessFs> for PathBeneath<'_> {}
 
+impl IntoIterator for PathBeneath<'_> {
+    type Item = Result<Self, AddRuleError<AccessFs>>;
+    type IntoIter = std::iter::Once<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        std::iter::once(Ok(self))
+    }
+}
+
 impl PrivateRule<AccessFs> for PathBeneath<'_> {
     fn as_ptr(&self) -> *const libc::c_void {
         &self.attr as *const _ as _

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -87,8 +87,8 @@ pub struct PathBeneath<'a> {
     is_best_effort: bool,
 }
 
-impl PathBeneath<'_> {
-    pub fn new<'a, T>(parent: &'a T) -> Self
+impl<'a> PathBeneath<'a> {
+    pub fn new<T>(parent: &'a T) -> Self
     where
         T: AsRawFd,
     {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,7 +1,7 @@
 use crate::{
     uapi, Access, AddRuleError, AddRulesError, CompatError, Compatibility, Compatible,
-    HandleAccessError, PathBeneathError, PathFdError, PrivateAccess, PrivateRule, Rule, Ruleset,
-    RulesetCreated, TryCompat, ABI,
+    HandleAccessError, HandleAccessesError, PathBeneathError, PathFdError, PrivateAccess,
+    PrivateRule, Rule, Ruleset, RulesetCreated, TryCompat, ABI,
 };
 use enumflags2::{bitflags, make_bitflags, BitFlags};
 use std::fs::{File, OpenOptions};
@@ -76,7 +76,11 @@ impl PrivateAccess for AccessFs {
     where
         E: std::error::Error,
     {
-        AddRulesError::AddRuleFs(error)
+        AddRulesError::Fs(error)
+    }
+
+    fn into_handle_accesses_error(error: HandleAccessError<Self>) -> HandleAccessesError {
+        HandleAccessesError::Fs(error)
     }
 }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,6 +1,6 @@
 use crate::{
-    uapi, AddRuleError, CompatError, Compatibility, Compatible, PathBeneathError, PathFdError,
-    PrivateRule, Rule, RulesetCreated, TryCompat, ABI,
+    uapi, Access, AddRuleError, CompatError, Compatibility, Compatible, PathBeneathError,
+    PathFdError, PrivateRule, Rule, RulesetCreated, TryCompat, ABI,
 };
 use enumflags2::{bitflags, make_bitflags, BitFlags};
 use std::fs::{File, OpenOptions};
@@ -59,6 +59,10 @@ impl From<ABI> for BitFlags<AccessFs> {
         }
     }
 }
+
+// It is useful for documentation generation to explicitely implement Access for every types,
+// instead of doing it generically.
+impl Access for AccessFs {}
 
 const ACCESS_FILE: BitFlags<AccessFs> = make_bitflags!(AccessFs::{
     ReadFile | WriteFile | Execute

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -162,11 +162,7 @@ impl Compatible for PathBeneath<'_> {
 fn path_beneath_try_compat() {
     use crate::*;
 
-    let compat = Compatibility {
-        abi: ABI::V1,
-        is_best_effort: true,
-        state: CompatState::Start,
-    };
+    let compat: Compatibility = ABI::V1.into();
 
     for file in &["/etc/passwd", "/dev/null"] {
         let mut compat_copy = compat.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use compat::{Compatible, ABI};
 pub use enumflags2::{make_bitflags, BitFlags};
 pub use errors::{
     AccessError, AddRuleError, CompatError, CreateRulesetError, HandleFsError, PathBeneathError,
-    RestrictSelfError,
+    PathFdError, RestrictSelfError, RulesetError,
 };
 pub use fs::{AccessFs, PathBeneath, PathFd};
 use ruleset::PrivateRule;
@@ -23,43 +23,33 @@ mod uapi;
 mod tests {
     use crate::*;
 
-    fn ruleset_root_compat() -> RestrictionStatus {
-        let ruleset: Ruleset = Compatibility::new().into();
-        ruleset
-            .handle_fs(ABI::V1)
-            .unwrap()
-            .create()
-            .unwrap()
-            .add_rule(PathBeneath::new(&PathFd::new("/").unwrap()).allow_access(ABI::V1))
-            .unwrap()
-            .restrict_self()
-            .unwrap()
+    fn ruleset_root_compat() -> Result<RestrictionStatus, RulesetError<AccessFs>> {
+        Ok(Ruleset::new()
+            .handle_fs(ABI::V1)?
+            .create()?
+            .add_rule(PathBeneath::new(&PathFd::new("/")?).allow_access(ABI::V1))?
+            .restrict_self()?)
     }
 
-    fn ruleset_root_fragile() -> RestrictionStatus {
+    fn ruleset_root_fragile() -> Result<RestrictionStatus, RulesetError<AccessFs>> {
         // Sets default support requirement: abort the whole sandboxing for any Landlock error.
-        Ruleset::new()
+        Ok(Ruleset::new()
             // Must have at least the execute check…
             .set_best_effort(false)
-            .handle_fs(AccessFs::Execute)
-            .unwrap()
+            .handle_fs(AccessFs::Execute)?
             // …and possibly others (superset of AccessFs::Execute).
             .set_best_effort(true)
-            .handle_fs(ABI::V1)
-            .unwrap()
-            .create()
-            .unwrap()
+            .handle_fs(ABI::V1)?
+            .create()?
             .set_no_new_privs(true)
-            .add_rule(PathBeneath::new(&PathFd::new("/").unwrap()).allow_access(ABI::V1))
-            .unwrap()
-            .restrict_self()
-            .unwrap()
+            .add_rule(PathBeneath::new(&PathFd::new("/")?).allow_access(ABI::V1))?
+            .restrict_self()?)
     }
 
     #[test]
     fn allow_root_compat() {
         assert_eq!(
-            ruleset_root_compat(),
+            ruleset_root_compat().unwrap(),
             RestrictionStatus {
                 ruleset: RulesetStatus::FullyEnforced,
                 no_new_privs: true,
@@ -70,7 +60,7 @@ mod tests {
     #[test]
     fn allow_root_fragile() {
         assert_eq!(
-            ruleset_root_fragile(),
+            ruleset_root_fragile().unwrap(),
             RestrictionStatus {
                 ruleset: RulesetStatus::FullyEnforced,
                 no_new_privs: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use compat::{CompatState, Compatibility, TryCompat};
 pub use compat::{Compatible, ABI};
 pub use enumflags2::{make_bitflags, BitFlags};
 pub use errors::{
-    AccessError, AddRuleError, CompatError, CreateRulesetError, HandleAccessError,
+    AccessError, AddRuleError, AddRulesError, CompatError, CreateRulesetError, HandleAccessError,
     PathBeneathError, PathFdError, RestrictSelfError, RulesetError,
 };
 pub use fs::{AccessFs, PathBeneath, PathFd};
@@ -23,7 +23,7 @@ mod uapi;
 mod tests {
     use crate::*;
 
-    fn ruleset_root_compat() -> Result<RestrictionStatus, RulesetError<AccessFs>> {
+    fn ruleset_root_compat() -> Result<RestrictionStatus, RulesetError<AccessFs, std::io::Error>> {
         Ok(Ruleset::new()
             .handle_access(AccessFs::from_all(ABI::V1))?
             .create()?
@@ -33,7 +33,7 @@ mod tests {
             .restrict_self()?)
     }
 
-    fn ruleset_root_fragile() -> Result<RestrictionStatus, RulesetError<AccessFs>> {
+    fn ruleset_root_fragile() -> Result<RestrictionStatus, RulesetError<AccessFs, std::io::Error>> {
         // Sets default support requirement: abort the whole sandboxing for any Landlock error.
         Ok(Ruleset::new()
             // Must have at least the execute check…

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ mod tests {
             .handle_access(AccessFs::from_all(ABI::V1))?
             .create()?
             .add_rule(
-                PathBeneath::new(&PathFd::new("/")?).allow_access(AccessFs::from_all(ABI::V1)),
+                PathBeneath::new(PathFd::new("/")?).allow_access(AccessFs::from_all(ABI::V1)),
             )?
             .restrict_self()?)
     }
@@ -45,7 +45,7 @@ mod tests {
             .create()?
             .set_no_new_privs(true)
             .add_rule(
-                PathBeneath::new(&PathFd::new("/")?).allow_access(AccessFs::from_all(ABI::V1)),
+                PathBeneath::new(PathFd::new("/")?).allow_access(AccessFs::from_all(ABI::V1)),
             )?
             .restrict_self()?)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,20 @@
 extern crate enumflags2;
+extern crate libc;
+extern crate thiserror;
 
 use compat::{CompatState, Compatibility, TryCompat};
 pub use compat::{Compatible, ABI};
 pub use enumflags2::{make_bitflags, BitFlags};
+pub use errors::{
+    AccessError, AddRuleError, CompatError, CreateRulesetError, HandleFsError, PathBeneathError,
+    RestrictSelfError,
+};
 pub use fs::{AccessFs, PathBeneath, PathFd};
 use ruleset::PrivateRule;
 pub use ruleset::{RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetStatus};
 
-#[cfg(test)]
-use std::io::Error;
-
 mod compat;
+mod errors;
 mod fs;
 mod ruleset;
 mod uapi;
@@ -19,34 +23,43 @@ mod uapi;
 mod tests {
     use crate::*;
 
-    fn ruleset_root_compat() -> Result<RestrictionStatus, Error> {
+    fn ruleset_root_compat() -> RestrictionStatus {
         let ruleset: Ruleset = Compatibility::new().into();
         ruleset
-            .handle_fs(ABI::V1)?
-            .create()?
-            .add_rule(PathBeneath::new(&PathFd::new("/")?).allow_access(ABI::V1))?
+            .handle_fs(ABI::V1)
+            .unwrap()
+            .create()
+            .unwrap()
+            .add_rule(PathBeneath::new(&PathFd::new("/").unwrap()).allow_access(ABI::V1))
+            .unwrap()
             .restrict_self()
+            .unwrap()
     }
 
-    fn ruleset_root_fragile() -> Result<RestrictionStatus, Error> {
+    fn ruleset_root_fragile() -> RestrictionStatus {
         // Sets default support requirement: abort the whole sandboxing for any Landlock error.
         Ruleset::new()
             // Must have at least the execute check…
             .set_best_effort(false)
-            .handle_fs(AccessFs::Execute)?
+            .handle_fs(AccessFs::Execute)
+            .unwrap()
             // …and possibly others (superset of AccessFs::Execute).
             .set_best_effort(true)
-            .handle_fs(ABI::V1)?
-            .create()?
+            .handle_fs(ABI::V1)
+            .unwrap()
+            .create()
+            .unwrap()
             .set_no_new_privs(true)
-            .add_rule(PathBeneath::new(&PathFd::new("/")?).allow_access(ABI::V1))?
+            .add_rule(PathBeneath::new(&PathFd::new("/").unwrap()).allow_access(ABI::V1))
+            .unwrap()
             .restrict_self()
+            .unwrap()
     }
 
     #[test]
     fn allow_root_compat() {
         assert_eq!(
-            ruleset_root_compat().unwrap(),
+            ruleset_root_compat(),
             RestrictionStatus {
                 ruleset: RulesetStatus::FullyEnforced,
                 no_new_privs: true,
@@ -57,7 +70,7 @@ mod tests {
     #[test]
     fn allow_root_fragile() {
         assert_eq!(
-            ruleset_root_fragile().unwrap(),
+            ruleset_root_fragile(),
             RestrictionStatus {
                 ruleset: RulesetStatus::FullyEnforced,
                 no_new_privs: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ pub use fs::{AccessFs, PathBeneath, PathFd};
 pub use ruleset::{Access, RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetStatus};
 use ruleset::{PrivateAccess, PrivateRule};
 
+#[cfg(test)]
+pub use errors::TestRulesetError;
+
 mod compat;
 mod errors;
 mod fs;
@@ -23,7 +26,7 @@ mod uapi;
 mod tests {
     use crate::*;
 
-    fn ruleset_root_compat() -> Result<RestrictionStatus, RulesetError<std::io::Error>> {
+    fn ruleset_root_compat() -> Result<RestrictionStatus, TestRulesetError> {
         Ok(Ruleset::new()
             .handle_access(AccessFs::from_all(ABI::V1))?
             .create()?
@@ -33,7 +36,7 @@ mod tests {
             .restrict_self()?)
     }
 
-    fn ruleset_root_fragile() -> Result<RestrictionStatus, RulesetError<std::io::Error>> {
+    fn ruleset_root_fragile() -> Result<RestrictionStatus, TestRulesetError> {
         // Sets default support requirement: abort the whole sandboxing for any Landlock error.
         Ok(Ruleset::new()
             // Must have at least the execute check…

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,12 @@ use compat::{CompatState, Compatibility, TryCompat};
 pub use compat::{Compatible, ABI};
 pub use enumflags2::{make_bitflags, BitFlags};
 pub use errors::{
-    AccessError, AddRuleError, CompatError, CreateRulesetError, HandleFsError, PathBeneathError,
-    PathFdError, RestrictSelfError, RulesetError,
+    AccessError, AddRuleError, CompatError, CreateRulesetError, HandleAccessError,
+    PathBeneathError, PathFdError, RestrictSelfError, RulesetError,
 };
 pub use fs::{AccessFs, PathBeneath, PathFd};
-use ruleset::PrivateRule;
 pub use ruleset::{Access, RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetStatus};
+use ruleset::{PrivateAccess, PrivateRule};
 
 mod compat;
 mod errors;
@@ -25,9 +25,11 @@ mod tests {
 
     fn ruleset_root_compat() -> Result<RestrictionStatus, RulesetError<AccessFs>> {
         Ok(Ruleset::new()
-            .handle_fs(ABI::V1)?
+            .handle_access(AccessFs::from_all(ABI::V1))?
             .create()?
-            .add_rule(PathBeneath::new(&PathFd::new("/")?).allow_access(ABI::V1))?
+            .add_rule(
+                PathBeneath::new(&PathFd::new("/")?).allow_access(AccessFs::from_all(ABI::V1)),
+            )?
             .restrict_self()?)
     }
 
@@ -36,13 +38,15 @@ mod tests {
         Ok(Ruleset::new()
             // Must have at least the execute check…
             .set_best_effort(false)
-            .handle_fs(AccessFs::Execute)?
+            .handle_access(AccessFs::Execute)?
             // …and possibly others (superset of AccessFs::Execute).
             .set_best_effort(true)
-            .handle_fs(ABI::V1)?
+            .handle_access(AccessFs::from_all(ABI::V1))?
             .create()?
             .set_no_new_privs(true)
-            .add_rule(PathBeneath::new(&PathFd::new("/")?).allow_access(ABI::V1))?
+            .add_rule(
+                PathBeneath::new(&PathFd::new("/")?).allow_access(AccessFs::from_all(ABI::V1)),
+            )?
             .restrict_self()?)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub use errors::{
 };
 pub use fs::{AccessFs, PathBeneath, PathFd};
 use ruleset::PrivateRule;
-pub use ruleset::{RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetStatus};
+pub use ruleset::{Access, RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetStatus};
 
 mod compat;
 mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use compat::{Compatible, ABI};
 pub use enumflags2::{make_bitflags, BitFlags};
 pub use errors::{
     AccessError, AddRuleError, AddRulesError, CompatError, CreateRulesetError, HandleAccessError,
-    PathBeneathError, PathFdError, RestrictSelfError, RulesetError,
+    HandleAccessesError, PathBeneathError, PathFdError, RestrictSelfError, RulesetError,
 };
 pub use fs::{AccessFs, PathBeneath, PathFd};
 pub use ruleset::{Access, RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetStatus};
@@ -23,7 +23,7 @@ mod uapi;
 mod tests {
     use crate::*;
 
-    fn ruleset_root_compat() -> Result<RestrictionStatus, RulesetError<AccessFs, std::io::Error>> {
+    fn ruleset_root_compat() -> Result<RestrictionStatus, RulesetError<std::io::Error>> {
         Ok(Ruleset::new()
             .handle_access(AccessFs::from_all(ABI::V1))?
             .create()?
@@ -33,7 +33,7 @@ mod tests {
             .restrict_self()?)
     }
 
-    fn ruleset_root_fragile() -> Result<RestrictionStatus, RulesetError<AccessFs, std::io::Error>> {
+    fn ruleset_root_fragile() -> Result<RestrictionStatus, RulesetError<std::io::Error>> {
         // Sets default support requirement: abort the whole sandboxing for any Landlock error.
         Ok(Ruleset::new()
             // Must have at least the execute check…

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -106,6 +106,8 @@ impl Ruleset {
 
     // TODO: Implement with DerefMut<Target = Ruleset> once arbitrary_self_types is in stable:
     // https://github.com/rust-lang/rust/issues/44874
+    // This would require to keep up-to-date the compatibility state even when an error occurs
+    // (anywhere), which would make the code more complex.
     pub fn handle_fs<T>(mut self, access: T) -> Result<Self, HandleFsError>
     where
         T: Into<BitFlags<AccessFs>>,

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -42,7 +42,7 @@ pub enum RulesetStatus {
 impl From<CompatState> for RulesetStatus {
     fn from(state: CompatState) -> Self {
         match state {
-            CompatState::Start | CompatState::No | CompatState::Final => RulesetStatus::NotEnforced,
+            CompatState::No | CompatState::Final => RulesetStatus::NotEnforced,
             CompatState::Full => RulesetStatus::FullyEnforced,
             CompatState::Partial => RulesetStatus::PartiallyEnforced,
         }

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -1,6 +1,6 @@
 use crate::{
     uapi, AccessFs, AddRuleError, AddRulesError, BitFlags, CompatState, Compatibility, Compatible,
-    CreateRulesetError, HandleAccessError, RestrictSelfError, TryCompat, ABI,
+    CreateRulesetError, HandleAccessError, HandleAccessesError, RestrictSelfError, TryCompat, ABI,
 };
 use enumflags2::BitFlag;
 use libc::close;
@@ -27,6 +27,10 @@ pub trait PrivateAccess: BitFlag {
     where
         Self: Access,
         E: std::error::Error;
+
+    fn into_handle_accesses_error(error: HandleAccessError<Self>) -> HandleAccessesError
+    where
+        Self: Access;
 }
 
 // Public interface without methods and which is impossible to implement outside this crate.
@@ -129,7 +133,7 @@ fn ruleset_add_rule_iter() {
             .unwrap()
             .add_rules(PathBeneath::new(PathFd::new("/").unwrap()).allow_access(AccessFs::ReadFile))
             .unwrap_err(),
-        AddRulesError::AddRuleFs(AddRuleError::UnhandledAccess { .. })
+        AddRulesError::Fs(AddRuleError::UnhandledAccess { .. })
     ));
 }
 

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -122,9 +122,7 @@ fn ruleset_add_rule_iter() {
             .unwrap()
             .create()
             .unwrap()
-            .add_rules(
-                PathBeneath::new(&PathFd::new("/").unwrap()).allow_access(AccessFs::ReadFile)
-            )
+            .add_rules(PathBeneath::new(PathFd::new("/").unwrap()).allow_access(AccessFs::ReadFile))
             .unwrap_err(),
         AddRulesError::AddRule(AddRuleError::UnhandledAccess { .. })
     ));
@@ -420,7 +418,7 @@ fn ruleset_unsupported() {
                 .create()
                 .unwrap()
                 .add_rule(
-                    PathBeneath::new(&PathFd::new("/").unwrap()).allow_access(AccessFs::ReadFile)
+                    PathBeneath::new(PathFd::new("/").unwrap()).allow_access(AccessFs::ReadFile)
                 )
                 .unwrap_err(),
             AddRuleError::UnhandledAccess { .. }

--- a/src/uapi/landlock.rs
+++ b/src/uapi/landlock.rs
@@ -41,16 +41,6 @@ fn bindgen_test_layout___kernel_fd_set() {
         8usize,
         concat!("Alignment of ", stringify!(__kernel_fd_set))
     );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<__kernel_fd_set>())).fds_bits as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__kernel_fd_set),
-            "::",
-            stringify!(fds_bits)
-        )
-    );
 }
 pub type __kernel_sighandler_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
@@ -90,16 +80,6 @@ fn bindgen_test_layout___kernel_fsid_t() {
         ::std::mem::align_of::<__kernel_fsid_t>(),
         4usize,
         concat!("Alignment of ", stringify!(__kernel_fsid_t))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<__kernel_fsid_t>())).val as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__kernel_fsid_t),
-            "::",
-            stringify!(val)
-        )
     );
 }
 pub type __kernel_off_t = __kernel_long_t;
@@ -147,18 +127,6 @@ fn bindgen_test_layout_landlock_ruleset_attr() {
         8usize,
         concat!("Alignment of ", stringify!(landlock_ruleset_attr))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<landlock_ruleset_attr>())).handled_access_fs as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(landlock_ruleset_attr),
-            "::",
-            stringify!(handled_access_fs)
-        )
-    );
 }
 #[doc = " @LANDLOCK_RULE_PATH_BENEATH: Type of a &struct"]
 #[doc = " landlock_path_beneath_attr ."]
@@ -191,30 +159,5 @@ fn bindgen_test_layout_landlock_path_beneath_attr() {
         ::std::mem::align_of::<landlock_path_beneath_attr>(),
         1usize,
         concat!("Alignment of ", stringify!(landlock_path_beneath_attr))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<landlock_path_beneath_attr>())).allowed_access as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(landlock_path_beneath_attr),
-            "::",
-            stringify!(allowed_access)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<landlock_path_beneath_attr>())).parent_fd as *const _ as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(landlock_path_beneath_attr),
-            "::",
-            stringify!(parent_fd)
-        )
     );
 }


### PR DESCRIPTION
Replace io::Error with high-level custom errors and fix some issues. This depends on #6 and #7.