### PR TITLE
Mixed consuming/mutable reference access to `RulesetCreated::add_rule`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,9 @@ pub use errors::{
     HandleAccessesError, PathBeneathError, PathFdError, RestrictSelfError, RulesetError,
 };
 pub use fs::{path_beneath_rules, AccessFs, PathBeneath, PathFd};
-pub use ruleset::{Access, RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetStatus};
+pub use ruleset::{
+    Access, RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetCreatedMut, RulesetStatus,
+};
 use ruleset::{PrivateAccess, PrivateRule};
 
 #[cfg(test)]

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -400,6 +400,20 @@ impl<'a> RulesetCreatedMut<'a> {
             },
         }
     }
+
+    pub fn add_rules<I, T, U, E>(&mut self, rules: I) -> Result<&mut Self, E>
+    where
+        I: IntoIterator<Item = Result<T, E>>,
+        T: Rule<U>,
+        U: Access,
+        E: std::error::Error,
+        E: From<RulesetError>,
+    {
+        for rule in rules {
+            self.add_rule(rule?)?;
+        }
+        Ok(self)
+    }
 }
 
 impl RulesetCreated {
@@ -532,9 +546,7 @@ impl RulesetCreated {
         E: std::error::Error,
         E: From<RulesetError>,
     {
-        for rule in rules {
-            self = self.add_rule(rule?)?;
-        }
+        self.as_mut().add_rules(rules)?;
         Ok(self)
     }
 

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -350,6 +350,7 @@ pub struct RulesetCreated {
     compat: Compatibility,
 }
 
+/// Mutable reference to a [`RulesetCreated`], obtained via [`RulesetCreated::as_mut()`].
 #[cfg_attr(test, derive(Debug))]
 pub struct RulesetCreatedMut<'a>(&'a mut RulesetCreated);
 
@@ -368,6 +369,7 @@ impl<'a> DerefMut for RulesetCreatedMut<'a> {
 }
 
 impl<'a> RulesetCreatedMut<'a> {
+    /// Non-consuming equivalent of [`RulesetCreated::add_rule()`].
     pub fn add_rule<T, U>(&mut self, rule: T) -> Result<&mut Self, RulesetError>
     where
         T: Rule<U>,
@@ -401,6 +403,7 @@ impl<'a> RulesetCreatedMut<'a> {
         }
     }
 
+    /// Non-consuming equivalent of [`RulesetCreated::add_rules()`].
     pub fn add_rules<I, T, U, E>(&mut self, rules: I) -> Result<&mut Self, E>
     where
         I: IntoIterator<Item = Result<T, E>>,
@@ -426,7 +429,7 @@ impl RulesetCreated {
         }
     }
 
-    /// Returns a wrapped mutable reference in order to use `add_rule` in a non-consuming way.
+    /// Returns a wrapped mutable reference in order to use [`RulesetCreated::add_rule`] in a non-consuming way.
     ///
     /// # Example
     ///

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -417,6 +417,12 @@ impl<'a> RulesetCreatedMut<'a> {
         }
         Ok(self)
     }
+
+    /// Non-consuming equivalent of [`RulesetCreated::set_no_new_privs()`].
+    pub fn set_no_new_privs(&mut self, no_new_privs: bool) -> &mut Self {
+        self.0.no_new_privs = no_new_privs;
+        self
+    }
 }
 
 impl RulesetCreated {


### PR DESCRIPTION
This patch takes the ideas discussed in #16 and implements a wrapper type, `RulesetCreatedMut` (following the standard library convention of using `Mut` to refer to mutable references, e.g. `AsMut` vs. `AsRef`).

- A `RulesetCreated::as_mut` method is created, which returns an instance of the newtype.
- The main, now non-consuming implementations are moved into the `RulesetCreatedMut::add_rule` and `RulesetCreatedMut::add_rules` methods, and are called by the original methods via `as_mut()` before returning `self`.
- The `set_no_new_privs` method is copied over, as it is a one-liner.

This should hopefully not be a breaking change for other dependents of `rust-landlock`, as the consuming API is left intact.

Having to explicitly go through `as_mut` to access the non-consuming methods might not be super intuitive, but I think it is a good, low-impact compromise.

There's still the issue of having to maintain duplicated methods going forward, but I believe that in order to implement any future method on the consuming side it would be enough to do a trivial call to the non-consuming side.

Thank you for your work on `rust-landlock`!