### PR TITLE
Non-consuming RulesetCreated alternative

### DIFF
--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -3,8 +3,8 @@
 
 use anyhow::{anyhow, bail};
 use landlock::{
-    Access, AccessFs, BitFlags, PathBeneath, PathFd, PathFdError, Ruleset, RulesetCreatedAttr,
-    RulesetError, RulesetStatus, ABI,
+    Access, AccessFs, BitFlags, PathBeneath, PathFd, PathFdError, Ruleset, RulesetAttr,
+    RulesetCreatedAttr, RulesetError, RulesetStatus, ABI,
 };
 use std::env;
 use std::ffi::OsStr;

--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -3,8 +3,8 @@
 
 use anyhow::{anyhow, bail};
 use landlock::{
-    Access, AccessFs, BitFlags, PathBeneath, PathFd, PathFdError, Ruleset, RulesetError,
-    RulesetStatus, ABI,
+    Access, AccessFs, BitFlags, PathBeneath, PathFd, PathFdError, Ruleset, RulesetCreatedAttr,
+    RulesetError, RulesetStatus, ABI,
 };
 use std::env;
 use std::ffi::OsStr;

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -283,7 +283,8 @@ pub trait Compatible {
     ///
     /// ```
     /// use landlock::{
-    ///     Access, AccessFs, Compatible, PathBeneath, Ruleset, RulesetCreated, RulesetError, ABI,
+    ///     Access, AccessFs, Compatible, PathBeneath, Ruleset, RulesetAttr, RulesetCreated, RulesetError,
+    ///     ABI,
     /// };
     ///
     /// fn ruleset_fragile() -> Result<RulesetCreated, RulesetError> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -64,7 +64,7 @@ pub enum CreateRulesetError {
     #[error("failed to create a ruleset: {source}")]
     #[non_exhaustive]
     CreateRulesetCall { source: io::Error },
-    /// Missing call to [`Ruleset::handle_access()`](crate::Ruleset::handle_access).
+    /// Missing call to [`RulesetAttr::handle_access()`](crate::RulesetAttr::handle_access).
     #[error("missing handled access")]
     MissingHandledAccess,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -126,12 +126,13 @@ where
 #[non_exhaustive]
 pub enum PathBeneathError {
     /// To check that access-rights are consistent with a file descriptor, a call to
-    /// [`RulesetCreated::add_rule()`](crate::RulesetCreated::add_rule)
+    /// [`RulesetCreatedAttr::add_rule()`](crate::RulesetCreatedAttr::add_rule)
     /// looks at the file type with an `fstat()` system call.
     #[error("failed to check file descriptor type: {source}")]
     #[non_exhaustive]
     StatCall { source: io::Error },
-    /// This error is returned by [`RulesetCreated::add_rule()`](crate::RulesetCreated::add_rule)
+    /// This error is returned by
+    /// [`RulesetCreatedAttr::add_rule()`](crate::RulesetCreatedAttr::add_rule)
     /// if the related PathBeneath object is not set to best-effort,
     /// and if its allowed access-rights contain directory-only ones
     /// whereas the file descriptor doesn't point to a directory.

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -129,14 +129,14 @@ fn consistent_access_fs_rw() {
 
 impl PrivateAccess for AccessFs {
     fn ruleset_handle_access(
-        mut ruleset: Ruleset,
+        ruleset: &mut Ruleset,
         access: BitFlags<Self>,
-    ) -> Result<Ruleset, HandleAccessesError> {
+    ) -> Result<(), HandleAccessesError> {
         ruleset.requested_handled_fs |= access;
         ruleset.actual_handled_fs |= access
             .try_compat(&mut ruleset.compat)
             .map_err(HandleAccessError::Compat)?;
-        Ok(ruleset)
+        Ok(())
     }
 
     fn into_add_rules_error(error: AddRuleError<Self>) -> AddRulesError {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -12,7 +12,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 
 #[cfg(test)]
-use crate::RulesetCreatedAttr;
+use crate::{RulesetAttr, RulesetCreatedAttr};
 #[cfg(test)]
 use strum::IntoEnumIterator;
 
@@ -421,7 +421,7 @@ fn path_fd() {
 ///
 /// ```
 /// use landlock::{
-///     ABI, Access, AccessFs, Ruleset, RulesetCreatedAttr, RulesetStatus, RulesetError,
+///     ABI, Access, AccessFs, Ruleset, RulesetAttr, RulesetCreatedAttr, RulesetStatus, RulesetError,
 ///     path_beneath_rules,
 /// };
 ///

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -12,6 +12,8 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 
 #[cfg(test)]
+use crate::RulesetCreatedAttr;
+#[cfg(test)]
 use strum::IntoEnumIterator;
 
 /// File system access right.
@@ -418,7 +420,10 @@ fn path_fd() {
 /// # Example
 ///
 /// ```
-/// use landlock::{ABI, Access, AccessFs, Ruleset, RulesetStatus, RulesetError, path_beneath_rules};
+/// use landlock::{
+///     ABI, Access, AccessFs, Ruleset, RulesetCreatedAttr, RulesetStatus, RulesetError,
+///     path_beneath_rules,
+/// };
 ///
 /// fn restrict_thread() -> Result<(), RulesetError> {
 ///     let abi = ABI::V1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,9 @@ pub use errors::{
     HandleAccessesError, PathBeneathError, PathFdError, RestrictSelfError, RulesetError,
 };
 pub use fs::{path_beneath_rules, AccessFs, PathBeneath, PathFd};
-pub use ruleset::{Access, RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetStatus};
+pub use ruleset::{
+    Access, RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetCreatedAttr, RulesetStatus,
+};
 use ruleset::{PrivateAccess, PrivateRule};
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,8 @@ pub use errors::{
 };
 pub use fs::{path_beneath_rules, AccessFs, PathBeneath, PathFd};
 pub use ruleset::{
-    Access, RestrictionStatus, Rule, Ruleset, RulesetCreated, RulesetCreatedAttr, RulesetStatus,
+    Access, RestrictionStatus, Rule, Ruleset, RulesetAttr, RulesetCreated, RulesetCreatedAttr,
+    RulesetStatus,
 };
 use ruleset::{PrivateAccess, PrivateRule};
 


### PR DESCRIPTION
This is an alternative implementation of #19, as I described in #16.

I think it is simpler than #19, with no duplicated method declarations. The main drawback is that we need to import the new `CreatedRulesetRef` trait.

What do you think @andreaphylum and @cd-work ?