### PR TITLE
Use OwnedFd and AsFd instead of AsRawFd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
 	"Vincent Dagonneau <vincentdagonneau@gmail.com>"
 ]
 edition = "2018"
+rust-version = "1.63"
 description = "Landlock LSM helpers"
 homepage = "https://landlock.io"
 repository = "https://github.com/landlock-lsm/rust-landlock"

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ More information about Landlock can be found in the [official website](https://l
 
 This Rust crate provides a safe abstraction for the Landlock system calls along with some helpers.
 See the [Rust Landlock API documentation](https://landlock.io/rust-landlock/landlock/).
+
+Minimum Supported Rust Version (MSRV): 1.63

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -99,11 +99,11 @@ fn support_no_new_privs() -> bool {
 ///     Access, AccessFs, PathBeneath, PathFd, RestrictionStatus, Ruleset, RulesetAttr,
 ///     RulesetCreatedAttr, RulesetError, ABI,
 /// };
-/// use std::os::unix::io::AsRawFd;
+/// use std::os::unix::io::AsFd;
 ///
 /// fn restrict_fd<T>(hierarchy: T) -> Result<RestrictionStatus, RulesetError>
 /// where
-///     T: AsRawFd,
+///     T: AsFd,
 /// {
 ///     // The Landlock ABI should be incremented (and tested) regularly.
 ///     let abi = ABI::V1;


### PR DESCRIPTION
See https://rust-lang.github.io/rfcs/3128-io-safety.html for the motivation behind this change.

Signed-off-by: Björn Roy Baron <bjorn3_gh@protonmail.com>

Opened as separate PR as requested at https://github.com/landlock-lsm/rust-landlock/pull/22#issuecomment-1370947341