### PR TITLE
Handle kernels with Landlock disabled

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -197,7 +197,7 @@ pub enum PathFdError {
 
 #[cfg(test)]
 #[derive(Debug, Error)]
-pub enum TestRulesetError {
+pub(crate) enum TestRulesetError {
     #[error(transparent)]
     Ruleset(#[from] RulesetError),
     #[error(transparent)]


### PR DESCRIPTION
It might be useful to run tests with a kernel supporting Landlock but explicitly disabling it (see the LSM stacking configuration).  In this case, the kernel returns EOPNOTSUPP which only matches the unstable ErrorKind::Uncategorized.

Even if tests helpers where only available when building tests, make them explicitly private outside this crate.
