### PR TITLE
Make AsFd compatible with Rust 1.63

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,9 +7,8 @@ use enumflags2::{bitflags, make_bitflags, BitFlags};
 use std::fs::OpenOptions;
 use std::io::Error;
 use std::mem::zeroed;
-use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::fs::OpenOptionsExt;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use std::path::Path;
 
 #[cfg(test)]


### PR DESCRIPTION
The std::os::fd module is only available with Rust 1.66, but before that and starting with Rust 1.63, only the std::os::unix::io module is available.

Fixes #25

Cc @bjorn3 