### PR TITLE
landlock: Bump to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "landlock"
-version = "0.1.0"
-authors = [
-	"Mickaël Salaün <mic@digikod.net>",
-	"Vincent Dagonneau <vincentdagonneau@gmail.com>"
-]
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.63"
 description = "Landlock LSM helpers"
@@ -12,6 +8,7 @@ homepage = "https://landlock.io"
 repository = "https://github.com/landlock-lsm/rust-landlock"
 license = "MIT OR Apache-2.0"
 keywords = ["access-control", "linux", "sandbox", "security"]
+categories = ["api-bindings", "os::linux-apis", "virtualization", "filesystem"]
 exclude = [".gitignore"]
 readme = "README.md"
 


### PR DESCRIPTION
Release a new crate version for current users before bringing more invasive API breaking changes (see #12 and #23).  The API is not ready to be stable yet but perfect is the enemy of good.

Switch to the 2021 Rust edition.

Remove the "authors" field.

Add four crate categories:
- api-bindings
- os::linux-apis
- virtualization
- filesystem

There is a limited set of categories and these ones make the more sense to me for now.

Cc @cd-work, @andreaphylum, @bjorn3, @rusty-snake, @r3dlight, @vdagonneau

Cf. phylum-dev/birdcage#19