### PR TITLE
Switch to the 2021 Rust edition

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,26 @@ jobs:
     - name: Run tests
       run: rustup run stable cargo test --verbose
 
+  ubuntu_18_rust_msrv:
+    runs-on: ubuntu-18.04
+    env:
+      # sed -n 's/^rust-version = "\([0-9.]\+\)"$/\1/p' Cargo.toml
+      RUST_TOOLCHAIN: 1.63
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust MSRV
+      run: |
+        rm ~/.cargo/bin/{cargo-fmt,rustfmt} || :
+        rustup default ${{ env.RUST_TOOLCHAIN }}
+        rustup update ${{ env.RUST_TOOLCHAIN }}
+
+    - name: Build
+      run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo build --verbose
+
+    - name: Build tests
+      run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo build --tests --verbose
+
   ubuntu_20_rust_stable:
     runs-on: ubuntu-20.04
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
 	"Mickaël Salaün <mic@digikod.net>",
 	"Vincent Dagonneau <vincentdagonneau@gmail.com>"
 ]
-edition = "2018"
+edition = "2021"
 rust-version = "1.63"
 description = "Landlock LSM helpers"
 homepage = "https://landlock.io"

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -116,11 +116,11 @@ lazy_static! {
             if ABI::is_known(n) || n == 0 {
                 ABI::from(n)
             } else {
-                panic!("Unknown ABI: {}", n);
+                panic!("Unknown ABI: {n}");
             }
         }
         Err(std::env::VarError::NotPresent) => ABI::iter().last().unwrap(),
-        Err(e) => panic!("Failed to read LANDLOCK_CRATE_TEST_ABI: {}", e),
+        Err(e) => panic!("Failed to read LANDLOCK_CRATE_TEST_ABI: {e}"),
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ mod tests {
             let ret = check(Ruleset::from(abi));
 
             // Useful for failed tests and with cargo test -- --show-output
-            println!("Checking ABI {:?}, expecting {:#?}", abi, ret);
+            println!("Checking ABI {abi:?}, expecting {ret:#?}");
             if can_emulate(abi, full) {
                 if abi < partial && error_if_abi_lt_partial {
                     // TODO: Check exact error type; this may require better error types.


### PR DESCRIPTION
Add changes required for the CI to pass.

Make sure any change is compatible with Rust 1.63, the current MSRV.