### PR TITLE
Initial duplicate RulesetCreated implementation

### DIFF
--- a/src/compat.rs
+++ b/src/compat.rs
@@ -255,7 +255,7 @@ fn compat_state_update_2() {
 }
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub(crate) struct Compatibility {
     abi: ABI,
     pub(crate) level: Option<CompatLevel>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,4 +343,21 @@ mod tests {
             false,
         );
     }
+
+    #[test]
+    fn ruleset_created_try_clone() {
+        check_ruleset_support(
+            ABI::V1,
+            Some(ABI::V1),
+            move |ruleset: Ruleset| -> _ {
+                Ok(ruleset
+                    .handle_access(AccessFs::Execute)?
+                    .create()?
+                    .add_rule(PathBeneath::new(PathFd::new("/")?, AccessFs::Execute))?
+                    .try_clone()?
+                    .restrict_self()?)
+            },
+            false,
+        );
+    }
 }


### PR DESCRIPTION
This is a simple extension to the RulesetCreated object to allow for the object to be duplicated to a potential down-level consumer that can apply the ruleset in another thread or process without consuming the initial Ruleset. This is helpful when you have builders that will want to contain a parent ruleset copy that can be applied multiple times to new forks/threads without the need to reconstruct the builder.

 It doesn't override clone to do this as there is not a great pattern for handling errors if we take that approach and `fcntl` can fail for a variety of reasons.

Tested on `Ubuntu 23.04 6.2.0-20-generic`.