### PR TITLE
Remove Ubuntu 18.04 from the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,31 +43,8 @@ jobs:
     outputs:
       commits: ${{ toJSON(steps.*.outputs.*) }}
 
-  ubuntu_18_rust_stable:
-    runs-on: ubuntu-18.04
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-    env:
-      LANDLOCK_CRATE_TEST_ABI: 0
-    steps:
-    - name: Install Rust stable
-      run: |
-        rm ~/.cargo/bin/{cargo-fmt,rustfmt} || :
-        rustup default stable
-        rustup update
-
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ matrix.commit }}
-
-    - name: Run tests
-      run: rustup run stable cargo test --verbose
-
-  ubuntu_18_rust_msrv:
-    runs-on: ubuntu-18.04
+  ubuntu_20_rust_msrv:
+    runs-on: ubuntu-20.04
     needs: commit_list
     strategy:
       fail-fast: false


### PR DESCRIPTION
Ubuntu 18.04 is now fully unsupported: https://github.com/actions/runner-images/issues/6002

Unfortunately, this removes tests with `LANDLOCK_CRATE_TEST_ABI: 0`, but I plan to get them back thanks to a custom UML kernel.