### PR TITLE
Execute each restrict_self() test in a dedicated thread

### DIFF
--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -663,20 +663,26 @@ fn ruleset_created_attr() {
         .unwrap();
 
     // ...and finally restrict with the last rules (thanks to non-lexical lifetimes).
-    ruleset_created
-        .set_compatibility(CompatLevel::BestEffort)
-        .add_rule(PathBeneath::new(
-            PathFd::new("/tmp").unwrap(),
-            AccessFs::Execute,
-        ))
-        .unwrap()
-        .add_rule(PathBeneath::new(
-            PathFd::new("/var").unwrap(),
-            AccessFs::Execute,
-        ))
-        .unwrap()
-        .restrict_self()
-        .unwrap();
+    assert_eq!(
+        ruleset_created
+            .set_compatibility(CompatLevel::BestEffort)
+            .add_rule(PathBeneath::new(
+                PathFd::new("/tmp").unwrap(),
+                AccessFs::Execute,
+            ))
+            .unwrap()
+            .add_rule(PathBeneath::new(
+                PathFd::new("/var").unwrap(),
+                AccessFs::Execute,
+            ))
+            .unwrap()
+            .restrict_self()
+            .unwrap(),
+        RestrictionStatus {
+            ruleset: RulesetStatus::NotEnforced,
+            no_new_privs: true,
+        }
+    );
 }
 
 #[test]


### PR DESCRIPTION
Ensures restrict_self() is called on a dedicated thread to avoid inconsistent tests.

The visible effect (with Rust 1.63) was for restrict_self() to sometime return E2BIG because of too many stacked domains. This inconsistency was related to the number of tests (i.e. the number of successful restrict_self() calls), but not directly related to their content.