### PR TITLE
Test with Landlock ABI 3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -171,3 +171,6 @@ jobs:
 
     - name: Run tests against Linux 6.1
       run: ./landlock-test-tools/test-rust.sh linux-6.1 2
+
+    - name: Run tests against Linux 6.4
+      run: ./landlock-test-tools/test-rust.sh linux-6.4 3


### PR DESCRIPTION
Run all tests against Linux 6.4.9 that supports Landlock ABI 3.

This completes the CI test suite, no need to run them elsewhere anymore.