### PR TITLE
ci: Update Ubunty 22.04.3 kernel

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     env:
-      LANDLOCK_CRATE_TEST_ABI: 1
+      LANDLOCK_CRATE_TEST_ABI: 3
     steps:
 
     - uses: actions/checkout@v3
@@ -137,7 +137,7 @@ jobs:
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     env:
-      LANDLOCK_CRATE_TEST_ABI: 1
+      LANDLOCK_CRATE_TEST_ABI: 3
       # $CARGO is used by landlock-test-tools/test-rust.sh
       CARGO: rustup run stable cargo
     steps:


### PR DESCRIPTION
GitHub CI updated Ubuntu 22.04 with Linux 6.2: https://ubuntu.com/about/release-cycle#ubuntu-kernel-release-cycle Reflect this change in the CI.

We could only rely on the new landlock-test-tools UML kernels, but this kind of Ubuntu update should not be frequent, and I'd still like to test with an Ubuntu kernel. Let's keep it for now, we'll update this CI configuration from time to time.