### PR TITLE
Make AsMut unambiguous

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,3 +1,4 @@
+use crate::compat::private::OptionCompatLevelMut;
 use crate::{
     uapi, Access, AddRuleError, AddRulesError, CompatError, CompatLevel, CompatResult, CompatState,
     Compatible, HandleAccessError, HandleAccessesError, PathBeneathError, PathFdError,
@@ -338,8 +339,14 @@ fn path_beneath_try_compat() {
     }
 }
 
-impl<F> AsMut<Option<CompatLevel>> for PathBeneath<F> {
-    fn as_mut(&mut self) -> &mut Option<CompatLevel> {
+impl<F> OptionCompatLevelMut for PathBeneath<F> {
+    fn as_option_compat_level_mut(&mut self) -> &mut Option<CompatLevel> {
+        &mut self.compat_level
+    }
+}
+
+impl<F> OptionCompatLevelMut for &mut PathBeneath<F> {
+    fn as_option_compat_level_mut(&mut self) -> &mut Option<CompatLevel> {
         &mut self.compat_level
     }
 }
@@ -353,7 +360,7 @@ fn path_beneath_compatibility() {
     let mut path = PathBeneath::new(PathFd::new("/").unwrap(), AccessFs::from_all(ABI::V1));
     let path_ref = &mut path;
 
-    let level = path_ref.as_mut();
+    let level = path_ref.as_option_compat_level_mut();
     assert_eq!(level, &None);
     assert_eq!(
         <Option<CompatLevel> as Into<CompatLevel>>::into(*level),
@@ -361,7 +368,10 @@ fn path_beneath_compatibility() {
     );
 
     path_ref.set_compatibility(CompatLevel::SoftRequirement);
-    assert_eq!(path_ref.as_mut(), &Some(CompatLevel::SoftRequirement));
+    assert_eq!(
+        path_ref.as_option_compat_level_mut(),
+        &Some(CompatLevel::SoftRequirement)
+    );
 
     path.set_compatibility(CompatLevel::HardRequirement);
 }

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -1,3 +1,4 @@
+use crate::compat::private::OptionCompatLevelMut;
 use crate::{
     uapi, Access, AccessFs, AddRuleError, AddRulesError, BitFlags, CompatLevel, CompatState,
     Compatibility, Compatible, CreateRulesetError, RestrictSelfError, RulesetError, TryCompat,
@@ -284,8 +285,14 @@ impl Ruleset {
     }
 }
 
-impl AsMut<Option<CompatLevel>> for Ruleset {
-    fn as_mut(&mut self) -> &mut Option<CompatLevel> {
+impl OptionCompatLevelMut for Ruleset {
+    fn as_option_compat_level_mut(&mut self) -> &mut Option<CompatLevel> {
+        &mut self.compat.level
+    }
+}
+
+impl OptionCompatLevelMut for &mut Ruleset {
+    fn as_option_compat_level_mut(&mut self) -> &mut Option<CompatLevel> {
         &mut self.compat.level
     }
 }
@@ -298,6 +305,20 @@ impl AsMut<Ruleset> for Ruleset {
     fn as_mut(&mut self) -> &mut Ruleset {
         self
     }
+}
+
+// Tests unambiguous type.
+#[test]
+fn ruleset_as_mut() {
+    let mut ruleset = Ruleset::from(ABI::Unsupported);
+    let _ = ruleset.as_mut();
+
+    let mut ruleset_created = Ruleset::from(ABI::Unsupported)
+        .handle_access(AccessFs::Execute)
+        .unwrap()
+        .create()
+        .unwrap();
+    let _ = ruleset_created.as_mut();
 }
 
 pub trait RulesetAttr: Sized + AsMut<Ruleset> + Compatible {
@@ -372,8 +393,14 @@ fn ruleset_created_handle_access_or() {
     ));
 }
 
-impl AsMut<Option<CompatLevel>> for RulesetCreated {
-    fn as_mut(&mut self) -> &mut Option<CompatLevel> {
+impl OptionCompatLevelMut for RulesetCreated {
+    fn as_option_compat_level_mut(&mut self) -> &mut Option<CompatLevel> {
+        &mut self.compat.level
+    }
+}
+
+impl OptionCompatLevelMut for &mut RulesetCreated {
+    fn as_option_compat_level_mut(&mut self) -> &mut Option<CompatLevel> {
         &mut self.compat.level
     }
 }


### PR DESCRIPTION
Remove AsMut<Option<CompatLevel>> from the public API to avoid ambiguous types that can lead to:
```
  error[E0283]: type annotations needed for `&mut T`
     --> src/ruleset.rs:306:9
      |
  306 |     let _ = ruleset.as_mut();
      |         ^           ------ type must be known at this point
      |
  note: multiple `impl`s satisfying `ruleset::Ruleset: AsMut<_>` found
```

Add tests to detect potential future change.

This is less elegant that the AsMut autoderivated implementations, but it is safer.

Fixes #48

Cc @cd-work 