### PR TITLE
Compatibility mode

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AccessError, AddRuleError, AddRulesError, BitFlags, CompatArg, CompatError, CompatResult,
+    AccessError, AddRuleError, AddRulesError, BitFlags, CompatAccess, CompatError, CompatResult,
     CompatibleArgument, HandleAccessError, HandleAccessesError, Ruleset, TailoredCompatLevel,
     TryCompat, ABI,
 };
@@ -8,14 +8,20 @@ use enumflags2::BitFlag;
 #[cfg(test)]
 use crate::{make_bitflags, AccessFs, CompatLevel, CompatState, Compatibility};
 
+/*
 pub trait Access
 where
-    Self: PrivateAccess
+    Self: PrivateAccess,
         + Into<BitFlags<Self>>
-        + Into<CompatArg<BitFlags<Self>>>
+        + Into<CompatAccess<Self>>,
         + CompatibleArgument<CompatSelf = BitFlags<Self>>,
     BitFlags<Self>:
-        Into<CompatArg<BitFlags<Self>>> + CompatibleArgument<CompatSelf = BitFlags<Self>>,
+        Into<CompatAccess<BitFlags<Self>>> + CompatibleArgument<CompatSelf = BitFlags<Self>>,
+        Into<CompatAccess<Self>>,
+*/
+pub trait Access
+where
+    Self: PrivateAccess,
 {
     /// Gets the access rights defined by a specific [`ABI`].
     /// Union of [`from_read()`](Access::from_read) and [`from_write()`](Access::from_write).
@@ -39,7 +45,8 @@ where
 pub trait PrivateAccess: BitFlag {
     fn ruleset_handle_access(
         ruleset: &mut Ruleset,
-        access: CompatArg<BitFlags<Self>>,
+        access: CompatAccess<Self>,
+        //access: CompatAccess<BitFlags<Self>>,
     ) -> Result<(), HandleAccessesError>
     where
         Self: Access;
@@ -201,28 +208,30 @@ fn compat_bit_flags() {
     ));
 }
 
-impl<A> From<A> for CompatArg<BitFlags<A>>
+/*
+impl<A> From<BitFlags<A>> for CompatAccess<A>
 where
     A: Access,
 {
-    fn from(access: A) -> Self {
-        let bitflags: BitFlags<A> = access.into();
-        bitflags.into()
+    fn from(access: BitFlags<A>) -> Self {
+        // XXX: How?
+        access.into()
     }
 }
+*/
 
 impl<A> CompatibleArgument for A
 where
     A: Access,
 {
-    type CompatSelf = BitFlags<A>;
+    type CompatSelf = A;
 }
 
 impl<A> CompatibleArgument for BitFlags<A>
 where
     A: Access,
 {
-    type CompatSelf = Self;
+    type CompatSelf = A;
 }
 
 #[test]

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -460,6 +460,28 @@ fn deprecated_set_best_effort() {
 }
 
 /// See the [`Compatible`] documentation.
+#[derive(Default)]
+pub enum CompatMode {
+    /// Takes into account the build requests if they are supported by the running system,
+    /// or silently ignores them otherwise.
+    /// Never returns a compatibility error.
+    #[default]
+    BestEffort,
+    /// Takes into account the build requests if they are supported by the running system,
+    /// or returns a compatibility error otherwise ([`CompatError`]).
+    ErrorIfUnmet,
+}
+
+impl From<CompatMode> for CompatLevel {
+    fn from(mode: CompatMode) -> Self {
+        match mode {
+            CompatMode::BestEffort => CompatLevel::BestEffort,
+            CompatMode::ErrorIfUnmet => CompatLevel::HardRequirement,
+        }
+    }
+}
+
+/// See the [`Compatible`] documentation.
 #[cfg_attr(test, derive(EnumIter))]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CompatLevel {

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -470,40 +470,145 @@ pub enum Consequence {
     ReturnError,
 }
 
-pub struct CompatArg<T> {
-    inner: T,
-    if_unmet: Consequence,
+use crate::BitFlags;
+
+// TODO: Remove Clone and Copy
+#[derive(Clone, Copy)]
+pub struct CompatAccess<A>
+where
+    A: Access,
+{
+    inner_continue: Option<BitFlags<A>>,
+    inner_disable_ruleset: Option<BitFlags<A>>,
+    inner_return_error: Option<BitFlags<A>>,
 }
 
-impl<T> CompatArg<T> {
-    pub fn unwrap_update(self, _current_abi: ABI, _compat_state: &mut CompatState) -> T {
+impl<A> CompatAccess<A>
+where
+    A: Access,
+{
+    pub fn unwrap_update(self, _current_abi: ABI, _compat_state: &mut CompatState) -> BitFlags<A> {
         /*
         match self.disable_sandbox_if_unmet {
             // Similar to CompatLevel::SoftRequirement
             compat_state.update(CompatState::Dummy);
         }
         */
-        self.inner
+        // FIXME:
+        self.inner_continue.unwrap()
     }
 }
 
-pub trait CompatibleArgument: Sized + Into<Self::CompatSelf> {
-    type CompatSelf;
-
-    fn if_unmet(self, consequence: Consequence) -> CompatArg<Self::CompatSelf> {
-        CompatArg {
-            inner: self.into(),
-            if_unmet: consequence,
+impl<A> Default for CompatAccess<A>
+where
+    A: Access,
+{
+    fn default() -> Self {
+        Self {
+            inner_continue: None,
+            inner_disable_ruleset: None,
+            inner_return_error: None,
         }
     }
 }
 
-impl<T> From<T> for CompatArg<T>
+impl<A> CompatAccess<A>
 where
-    T: CompatibleArgument<CompatSelf = T>,
+    A: Access,
 {
-    fn from(inner: T) -> Self {
-        inner.if_unmet(Consequence::default())
+    // FIXME: Use CompatError
+    //fn try_inner(self, abi: ABI) -> Result<Option<BitFlags<A>>, CompatError<A>> {
+    //fn try_compat_inner(self, abi: ABI) -> Result<CompatResult<BitFlags<A>, A>, CompatError<A>> {
+    fn try_compat_inner(self, abi: ABI) -> Result<UnmetAction<A>, UnmetError> {
+        let mut has_access = false;
+        if let Some(inner_return_error) = self.inner_return_error {
+            match inner_return_error.try_compat_inner(abi)? {
+                CompatResult::Full(_) => has_access = true,
+                //CompatResult::Partial(_, _) => return Err(UnmetError),
+                //CompatResult::No(_) => return Err(UnmetError),
+                // TODO: Include unmet access rights in UnmetError.
+                _ => return Err(UnmetError),
+            };
+        }
+        if let Some(inner_disable_ruleset) = self.inner_disable_ruleset {
+            match inner_disable_ruleset.try_compat_inner(abi)? {
+                CompatResult::Full(_) => has_access = true,
+                // TODO: Include unmet access rights in DisableRuleset.
+                _ => return Ok(UnmetAction::DisableRuleset),
+            };
+        }
+        if let Some(inner_continue) = self.inner_continue {
+            let _ = inner_continue.try_compat_inner(abi)?;
+            has_access = true;
+        }
+        if !has_access {
+            // FIXME: add dedicated error
+            return Err(UnmetError);
+        }
+        Ok(UnmetAction::Continue(
+            self.inner_return_error.unwrap_or_default()
+                | self.inner_disable_ruleset.unwrap_or_default()
+                | self.inner_continue.unwrap_or_default(),
+        ))
+    }
+}
+
+pub trait CompatibleArgument
+where
+    Self: Into<CompatAccess<Self::CompatSelf>>,
+    Self::CompatSelf: Access,
+{
+    type CompatSelf;
+
+    // TODO: Move if_unmet() to the CompatibleArgument trait (and keep its name for genericity),
+    // implemented for all Access implementation and all BitFlags<A>.
+    //fn if_unmet(self, consequence: Consequence) -> Self {
+    fn if_unmet(self, consequence: Consequence) -> CompatAccess<Self::CompatSelf> {
+        let compat_self = self.into();
+        let has_access = compat_self.inner_continue.is_some()
+            || compat_self.inner_disable_ruleset.is_some()
+            || compat_self.inner_return_error.is_some();
+        let option_access = || {
+            if has_access {
+                Some(
+                    compat_self.inner_continue.unwrap_or_default()
+                        | compat_self.inner_disable_ruleset.unwrap_or_default()
+                        | compat_self.inner_return_error.unwrap_or_default(),
+                )
+            } else {
+                None
+            }
+        };
+        match consequence {
+            Consequence::Continue => CompatAccess {
+                inner_continue: option_access(),
+                ..Default::default()
+            },
+            Consequence::DisableRuleset => CompatAccess {
+                inner_disable_ruleset: option_access(),
+                ..Default::default()
+            },
+            Consequence::ReturnError => CompatAccess {
+                inner_return_error: option_access(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl<A, B> From<B> for CompatAccess<A>
+where
+    A: Access,
+    B: Into<BitFlags<A>>,
+    // TODO: Move as Access requirement
+    //A: CompatibleArgument<CompatSelf = A>,
+{
+    fn from(access: B) -> Self {
+        // Best-effort approach by default: Consequence::Continue
+        Self {
+            inner_continue: Some(access.into()),
+            ..Default::default()
+        }
     }
 }
 
@@ -734,4 +839,41 @@ where
             }
         }
     }
+}
+
+use thiserror::Error;
+
+/*
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct UnmetError<A>
+where
+    A: Access,
+(
+    #[from] A
+);
+*/
+
+#[derive(Debug, Error)]
+#[error("failed to meet the required access")]
+pub struct UnmetError;
+
+impl<A> From<CompatError<A>> for UnmetError
+where
+    A: Access,
+{
+    fn from(_: CompatError<A>) -> Self {
+        Self
+    }
+}
+
+pub enum UnmetAction<A>
+where
+    A: Access,
+{
+    // Fully matches the request.
+    Continue(BitFlags<A>),
+    // Partially matches the request.
+    //DisableRuleset(BitFlags<A>),
+    DisableRuleset,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,9 @@
 extern crate lazy_static;
 
 pub use access::Access;
-pub use compat::{CompatLevel, CompatMode, Compatible, ABI};
+pub use compat::{
+    CompatArg, CompatLevel, CompatMode, Compatible, CompatibleArgument, Consequence, ABI,
+};
 pub use enumflags2::{make_bitflags, BitFlags};
 pub use errors::{
     AccessError, AddRuleError, AddRulesError, CompatError, CreateRulesetError, HandleAccessError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ extern crate lazy_static;
 
 pub use access::Access;
 pub use compat::{
-    CompatArg, CompatLevel, CompatMode, Compatible, CompatibleArgument, Consequence, ABI,
+    CompatAccess, CompatLevel, CompatMode, Compatible, CompatibleArgument, Consequence, ABI,
 };
 pub use enumflags2::{make_bitflags, BitFlags};
 pub use errors::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 extern crate lazy_static;
 
 pub use access::Access;
-pub use compat::{CompatLevel, Compatible, ABI};
+pub use compat::{CompatLevel, CompatMode, Compatible, ABI};
 pub use enumflags2::{make_bitflags, BitFlags};
 pub use errors::{
     AccessError, AddRuleError, AddRulesError, CompatError, CreateRulesetError, HandleAccessError,

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -1,8 +1,8 @@
 use crate::compat::private::OptionCompatLevelMut;
 use crate::{
-    uapi, Access, AccessFs, AddRuleError, AddRulesError, BitFlags, CompatLevel, CompatMode,
-    CompatState, Compatibility, Compatible, CreateRulesetError, RestrictSelfError, RulesetError,
-    TryCompat,
+    uapi, Access, AccessFs, AddRuleError, AddRulesError, BitFlags, CompatArg, CompatLevel,
+    CompatMode, CompatState, Compatibility, Compatible, CreateRulesetError, RestrictSelfError,
+    RulesetError, TryCompat,
 };
 use libc::close;
 use std::io::Error;
@@ -233,7 +233,7 @@ impl Ruleset {
     {
         Self::default()
             .set_compatibility(mode.into())
-            .handle_access(handle_access)
+            .handle_access(handle_access.into())
     }
 
     /*
@@ -348,7 +348,8 @@ pub trait RulesetAttr: Sized + AsMut<Ruleset> + Compatible {
     /// E.g., `RulesetError::HandleAccesses(HandleAccessesError::Fs(HandleAccessError<AccessFs>))`
     fn handle_access<T, U>(mut self, access: T) -> Result<Self, RulesetError>
     where
-        T: Into<BitFlags<U>>,
+        T: Into<CompatArg<BitFlags<U>>>,
+        //T: Into<BitFlags<U>> // XXX: CompatibleArgument is not required but could help users
         U: Access,
     {
         U::ruleset_handle_access(self.as_mut(), access.into())?;

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -1,7 +1,8 @@
 use crate::compat::private::OptionCompatLevelMut;
 use crate::{
-    uapi, Access, AccessFs, AddRuleError, AddRulesError, BitFlags, CompatLevel, CompatState,
-    Compatibility, Compatible, CreateRulesetError, RestrictSelfError, RulesetError, TryCompat,
+    uapi, Access, AccessFs, AddRuleError, AddRulesError, BitFlags, CompatLevel, CompatMode,
+    CompatState, Compatibility, Compatible, CreateRulesetError, RestrictSelfError, RulesetError,
+    TryCompat,
 };
 use libc::close;
 use std::io::Error;
@@ -222,11 +223,26 @@ impl Default for Ruleset {
 }
 
 impl Ruleset {
-    #[allow(clippy::new_without_default)]
-    #[deprecated(note = "Use Ruleset::default() instead")]
-    pub fn new() -> Self {
-        Ruleset::default()
+    /// Returns a new `Ruleset` with a specific compatibility mode.
+    ///
+    /// In most cases we should use [`Ruleset::default()`] instead.
+    pub fn new<T, U>(mode: CompatMode, handle_access: T) -> Result<Self, RulesetError>
+    where
+        T: Into<BitFlags<U>>,
+        U: Access,
+    {
+        Self::default()
+            .set_compatibility(mode.into())
+            .handle_access(handle_access)
     }
+
+    /*
+    // TODO:
+    #[cfg(test)]
+    pub(crate) fn new_from(mode: CompatMode, abi: ABI) -> Self {
+        Self::from(abi).set_compatibility(mode.into())
+    }
+    */
 
     /// Attempts to create a real Landlock ruleset (if supported by the running kernel).
     /// The returned [`RulesetCreated`] is also a builder.

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -1,6 +1,6 @@
 use crate::compat::private::OptionCompatLevelMut;
 use crate::{
-    uapi, Access, AccessFs, AddRuleError, AddRulesError, BitFlags, CompatArg, CompatLevel,
+    uapi, Access, AccessFs, AddRuleError, AddRulesError, BitFlags, CompatAccess, CompatLevel,
     CompatMode, CompatState, Compatibility, Compatible, CreateRulesetError, RestrictSelfError,
     RulesetError, TryCompat,
 };
@@ -228,7 +228,7 @@ impl Ruleset {
     /// In most cases we should use [`Ruleset::default()`] instead.
     pub fn new<T, U>(mode: CompatMode, handle_access: T) -> Result<Self, RulesetError>
     where
-        T: Into<BitFlags<U>>,
+        T: Into<CompatAccess<U>>,
         U: Access,
     {
         Self::default()
@@ -348,7 +348,7 @@ pub trait RulesetAttr: Sized + AsMut<Ruleset> + Compatible {
     /// E.g., `RulesetError::HandleAccesses(HandleAccessesError::Fs(HandleAccessError<AccessFs>))`
     fn handle_access<T, U>(mut self, access: T) -> Result<Self, RulesetError>
     where
-        T: Into<CompatArg<BitFlags<U>>>,
+        T: Into<CompatAccess<U>>,
         //T: Into<BitFlags<U>> // XXX: CompatibleArgument is not required but could help users
         U: Access,
     {


### PR DESCRIPTION
Update `Ruleset::new()` to take a `CompatMode` argument, and add the required dependencies to handle incompatibility consequences with `if_unmet()`, `CompatAccess`...

See rationale here: https://fosdem.org/2023/schedule/event/rust_backward_and_forward_compatibility_for_security_features/

[Proposal](https://github.com/landlock-lsm/rust-landlock/pull/12#discussion_r1063685914):
- add a new (alternative) constructor to `Ruleset` to be able to enforce a  "hard requirement" for everything (set to "best effort" with the `default()` constructor: #44);
- add a method to access rights to be able to set the "soft requirement" property.

Example with current API:
```rust
Ruleset::new()
    .set_compatibility(CompatLevel::HardRequirement)
    .handle_access(AccessFs::from_all(ABI::V1))?
    .set_compatibility(CompatLevel::SoftRequirement)
    .handle_access(AccessFs::Refer)?
    .set_compatibility(CompatLevel::HardRequirement)
```

Same example with the proposed API:
```rust
Ruleset::new(CompatMode::ErrorIfUnmet) 
    .handle_access(AccessFs::from_all(ABI::V1))?
    .handle_access(AccessFs::Refer.if_unmet(Consequence::DisableRuleset))?
```

Example with the best effort behavior:
```rust
Ruleset::default() 
    .handle_access(AccessFs::from_all(ABI::V1))?
    .handle_access(AccessFs::Refer)?
```

This design is simpler and it removes the mutable builder property (multiple `.set_compatibility()` calls) that may be confusing and error prone. 

I started working on that a while ago but the code is still WIP.