### PR TITLE
Update error priority and no_new_privs behavior

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -127,7 +127,7 @@ fn compat_bit_flags() {
     compat = ABI::Unsupported.into();
 
     // Tests that the ruleset is marked as unsupported.
-    assert!(compat.state == CompatState::No);
+    assert!(compat.state == CompatState::Dummy);
 
     // Access-rights are valid (but ignored) when they are not required for the current ABI.
     assert_eq!(
@@ -139,7 +139,7 @@ fn compat_bit_flags() {
 
     // Tests that the ruleset is in an unsupported state, which is important to be able to still
     // enforce no_new_privs.
-    assert!(compat.state == CompatState::No);
+    assert!(compat.state == CompatState::Dummy);
 
     // Access-rights are not valid when they are required for the current ABI.
     compat.level = Some(CompatLevel::HardRequirement);

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -269,7 +269,7 @@ impl From<ABI> for Compatibility {
             level: Default::default(),
             state: match abi {
                 // Don't forces the state as Dummy because no_new_privs may still be legitimate.
-                ABI::Unsupported => CompatState::No,
+                ABI::Unsupported => CompatState::Dummy,
                 _ => CompatState::Init,
             },
         }

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -562,7 +562,7 @@ pub struct RulesetCreated {
 }
 
 impl RulesetCreated {
-    fn new(ruleset: Ruleset, fd: RawFd) -> Self {
+    pub(crate) fn new(ruleset: Ruleset, fd: RawFd) -> Self {
         // The compatibility state is initialized by Ruleset::create().
         #[cfg(test)]
         assert!(!matches!(ruleset.compat.state, CompatState::Init));


### PR DESCRIPTION
This set of changes fix and improve error management. This is also a requirement to properly check port overflow in #55.

This also changes the behavior of `prctl(PR_SET_NO_NEW_PRIVS, 1)`, which is now always called (in `restrict_self()`), even when `SoftRequirement` was explicitly set and the ruleset was made moot (because of the running kernel not supporting a feature). This should not be an issue in practice because `PR_SET_NO_NEW_PRIVS` supported by very old kernels. Anyway, this will be part of a release with a new major version.