### PR TITLE
Fix and test unsupported rule

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -129,7 +129,7 @@ fn compat_bit_flags() {
     compat = ABI::Unsupported.into();
 
     // Tests that the ruleset is marked as unsupported.
-    assert!(compat.state == CompatState::Dummy);
+    assert!(compat.state == CompatState::Init);
 
     // Access-rights are valid (but ignored) when they are not required for the current ABI.
     assert_eq!(
@@ -139,9 +139,7 @@ fn compat_bit_flags() {
             .unwrap()
     );
 
-    // Tests that the ruleset is in an unsupported state, which is important to be able to still
-    // enforce no_new_privs.
-    assert!(compat.state == CompatState::Dummy);
+    assert!(compat.state == CompatState::No);
 
     // Access-rights are not valid when they are required for the current ABI.
     compat.level = Some(CompatLevel::HardRequirement);

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -267,11 +267,7 @@ impl From<ABI> for Compatibility {
         Compatibility {
             abi,
             level: Default::default(),
-            state: match abi {
-                // Don't forces the state as Dummy because no_new_privs may still be legitimate.
-                ABI::Unsupported => CompatState::Dummy,
-                _ => CompatState::Init,
-            },
+            state: CompatState::Init,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,6 +338,7 @@ mod tests {
                     .handle_access(AccessFs::Refer)?
                     .handle_access(AccessFs::Truncate)?
                     .create()?
+                    .add_rule(PathBeneath::new(PathFd::new("/")?, AccessFs::Refer))?
                     .restrict_self()?)
             },
             false,


### PR DESCRIPTION
We should never try to add real rules to a ruleset that wasn't really created (i.e. with a -1 file descriptor).

Fix the From implementation for Compatibilty to always use CompatState::Init as an initial state.  This is now possible because of the changes in create(), especially the new handling of no_new_privs.

Simplify Ruleset:create() to only rely on compatibility state, which is now always correct.  This is more future proof and this will help for upcoming restrictions.

Extend the abi_v3_truncate() test to check with a new rule which may be incompatible.

Fixes #67 