### PR TITLE
Update to thiserror version 2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 [dependencies]
 enumflags2 = "0.7"
 libc = "0.2.133"
-thiserror = "1.0"
+thiserror = "2.0"
 
 [dev-dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
The breaking changes between version 1 and 2 do not affect rust-landlock's usage of thiserror.