### PR TITLE
Add the Errno helper

### DIFF
--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -1024,3 +1024,15 @@ fn unsupported_handled_access() {
         )))
     );
 }
+
+#[test]
+fn unsupported_handled_access_errno() {
+    assert_eq!(
+        Errno::from(
+            Ruleset::from(ABI::V3)
+                .handle_access(AccessNet::from_all(ABI::V3))
+                .unwrap_err()
+        ),
+        Errno::new(libc::EINVAL)
+    );
+}


### PR DESCRIPTION
This helper is useful for FFI to easily translate a Landlock error into an errno value.

Extend check_ruleset_support() with errno translation tests.

Add the unsupported_handled_access_errno() test.