### PR TITLE
tests: add case for AccessFs::from_file

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -156,8 +156,10 @@ fn consistent_access_fs_rw() {
         let access_all = AccessFs::from_all(abi);
         let access_read = AccessFs::from_read(abi);
         let access_write = AccessFs::from_write(abi);
+        let access_file = AccessFs::from_file(abi);
         assert_eq!(access_read, !access_write & access_all);
         assert_eq!(access_read | access_write, access_all);
+        assert_eq!(access_file, access_all & ACCESS_FILE);
     }
 }
 


### PR DESCRIPTION
It's a minor change, but I've been having some problems with using `from_file` in Ubuntu 22.04 and wrote this to be extra sure that I wasn't overseeing something super trivial. Thought it might turn out to be useful later down the line.