### PR TITLE
Document HandledAccess

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -7,12 +7,17 @@ use enumflags2::BitFlag;
 #[cfg(test)]
 use crate::{make_bitflags, AccessFs, CompatLevel, CompatState, Compatibility};
 
-pub trait Access: private::Sealed + BitFlag {
+pub trait Access: BitFlag + private::Sealed {
     /// Gets the access rights defined by a specific [`ABI`].
     fn from_all(abi: ABI) -> BitFlags<Self>;
 }
 
-pub trait HandledAccess: Access {
+// This HandledAccess trait is useful to document the API.
+pub trait HandledAccess: Access {}
+
+impl<A> HandledAccess for A where A: PrivateHandledAccess {}
+
+pub trait PrivateHandledAccess: HandledAccess {
     fn ruleset_handle_access(
         ruleset: &mut Ruleset,
         access: BitFlags<Self>,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use crate::{Access, AccessFs, AccessNet, BitFlags, HandledAccess, Scope};
+use crate::{Access, AccessFs, AccessNet, BitFlags, HandledAccess, PrivateHandledAccess, Scope};
 use std::io;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -61,7 +61,7 @@ pub enum HandleAccessesError {
 // listed in HandleAccessesError (with #[from]).
 impl<A> From<HandleAccessError<A>> for HandleAccessesError
 where
-    A: HandledAccess,
+    A: PrivateHandledAccess,
 {
     fn from(error: HandleAccessError<A>) -> Self {
         A::into_handle_accesses_error(error)
@@ -87,7 +87,7 @@ pub enum CreateRulesetError {
 #[non_exhaustive]
 pub enum AddRuleError<T>
 where
-    T: Access,
+    T: HandledAccess,
 {
     /// The `landlock_add_rule()` system call failed.
     #[error("failed to add a rule: {source}")]
@@ -107,7 +107,7 @@ where
 // in AddRulesError (with #[from]).
 impl<A> From<AddRuleError<A>> for AddRulesError
 where
-    A: HandledAccess,
+    A: PrivateHandledAccess,
 {
     fn from(error: AddRuleError<A>) -> Self {
         A::into_add_rules_error(error)

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,9 +1,9 @@
 use crate::compat::private::OptionCompatLevelMut;
 use crate::{
     uapi, Access, AddRuleError, AddRulesError, CompatError, CompatLevel, CompatResult, CompatState,
-    Compatible, HandleAccessError, HandleAccessesError, HandledAccess, PathBeneathError,
-    PathFdError, PrivateRule, Rule, Ruleset, RulesetCreated, RulesetError, TailoredCompatLevel,
-    TryCompat, ABI,
+    Compatible, HandleAccessError, HandleAccessesError, PathBeneathError, PathFdError,
+    PrivateHandledAccess, PrivateRule, Rule, Ruleset, RulesetCreated, RulesetError,
+    TailoredCompatLevel, TryCompat, ABI,
 };
 use enumflags2::{bitflags, make_bitflags, BitFlags};
 use std::fs::OpenOptions;
@@ -159,7 +159,7 @@ fn consistent_access_fs_rw() {
     }
 }
 
-impl HandledAccess for AccessFs {
+impl PrivateHandledAccess for AccessFs {
     fn ruleset_handle_access(
         ruleset: &mut Ruleset,
         access: BitFlags<Self>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-pub use access::Access;
+pub use access::{Access, HandledAccess};
 pub use compat::{CompatLevel, Compatible, ABI};
 pub use enumflags2::{make_bitflags, BitFlags};
 pub use errors::{
@@ -95,7 +95,7 @@ pub use ruleset::{
 };
 pub use scope::Scope;
 
-use access::HandledAccess;
+use access::PrivateHandledAccess;
 use compat::{CompatResult, CompatState, Compatibility, TailoredCompatLevel, TryCompat};
 use ruleset::PrivateRule;
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,8 +1,8 @@
 use crate::compat::private::OptionCompatLevelMut;
 use crate::{
     uapi, Access, AddRuleError, AddRulesError, CompatError, CompatLevel, CompatResult, CompatState,
-    Compatible, HandleAccessError, HandleAccessesError, HandledAccess, PrivateRule, Rule, Ruleset,
-    RulesetCreated, TailoredCompatLevel, TryCompat, ABI,
+    Compatible, HandleAccessError, HandleAccessesError, PrivateHandledAccess, PrivateRule, Rule,
+    Ruleset, RulesetCreated, TailoredCompatLevel, TryCompat, ABI,
 };
 use enumflags2::{bitflags, BitFlags};
 use std::mem::zeroed;
@@ -60,7 +60,7 @@ impl Access for AccessNet {
     }
 }
 
-impl HandledAccess for AccessNet {
+impl PrivateHandledAccess for AccessNet {
     fn ruleset_handle_access(
         ruleset: &mut Ruleset,
         access: BitFlags<Self>,

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -1,8 +1,8 @@
 use crate::compat::private::OptionCompatLevelMut;
 use crate::{
     uapi, AccessFs, AccessNet, AddRuleError, AddRulesError, BitFlags, CompatLevel, CompatState,
-    Compatibility, Compatible, CreateRulesetError, HandledAccess, RestrictSelfError, RulesetError,
-    Scope, ScopeError, TryCompat,
+    Compatibility, Compatible, CreateRulesetError, HandledAccess, PrivateHandledAccess,
+    RestrictSelfError, RulesetError, Scope, ScopeError, TryCompat,
 };
 use libc::close;
 use std::io::Error;
@@ -347,7 +347,7 @@ pub trait RulesetAttr: Sized + AsMut<Ruleset> + Compatible {
     fn handle_access<T, U>(mut self, access: T) -> Result<Self, RulesetError>
     where
         T: Into<BitFlags<U>>,
-        U: HandledAccess,
+        U: HandledAccess + PrivateHandledAccess,
     {
         U::ruleset_handle_access(self.as_mut(), access.into())?;
         Ok(self)
@@ -580,7 +580,7 @@ pub trait RulesetCreatedAttr: Sized + AsMut<RulesetCreated> + Compatible {
     fn add_rule<T, U>(mut self, rule: T) -> Result<Self, RulesetError>
     where
         T: Rule<U>,
-        U: HandledAccess,
+        U: HandledAccess + PrivateHandledAccess,
     {
         let body = || -> Result<Self, AddRulesError> {
             let self_ref = self.as_mut();
@@ -690,7 +690,7 @@ pub trait RulesetCreatedAttr: Sized + AsMut<RulesetCreated> + Compatible {
     where
         I: IntoIterator<Item = Result<T, E>>,
         T: Rule<U>,
-        U: HandledAccess,
+        U: HandledAccess + PrivateHandledAccess,
         E: From<RulesetError>,
     {
         for rule in rules {


### PR DESCRIPTION
With commit 554217dda0b7 ("access: Make Access independant from HandledAccess"), the documentation about RulesetCreated::handle_access() lists HandledAccess as an argument's requirement, but because this trait is private, there is no list of types implementing this trait, which is confusing.

Move private methods to a new PrivateHandledAccess trait and use HandledAccess as a way to document the argument's requirement.

Fix AddRuleError requirement.

Cf. #96