### PR TITLE
Make HandledAccess implementations explicit

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -15,8 +15,6 @@ pub trait Access: BitFlag + private::Sealed {
 // This HandledAccess trait is useful to document the API.
 pub trait HandledAccess: Access {}
 
-impl<A> HandledAccess for A where A: PrivateHandledAccess {}
-
 pub trait PrivateHandledAccess: HandledAccess {
     fn ruleset_handle_access(
         ruleset: &mut Ruleset,

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,8 +1,8 @@
 use crate::compat::private::OptionCompatLevelMut;
 use crate::{
     uapi, Access, AddRuleError, AddRulesError, CompatError, CompatLevel, CompatResult, CompatState,
-    Compatible, HandleAccessError, HandleAccessesError, PathBeneathError, PathFdError,
-    PrivateHandledAccess, PrivateRule, Rule, Ruleset, RulesetCreated, RulesetError,
+    Compatible, HandleAccessError, HandleAccessesError, HandledAccess, PathBeneathError,
+    PathFdError, PrivateHandledAccess, PrivateRule, Rule, Ruleset, RulesetCreated, RulesetError,
     TailoredCompatLevel, TryCompat, ABI,
 };
 use enumflags2::{bitflags, make_bitflags, BitFlags};
@@ -158,6 +158,8 @@ fn consistent_access_fs_rw() {
         assert_eq!(access_read | access_write, access_all);
     }
 }
+
+impl HandledAccess for AccessFs {}
 
 impl PrivateHandledAccess for AccessFs {
     fn ruleset_handle_access(

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,8 +1,8 @@
 use crate::compat::private::OptionCompatLevelMut;
 use crate::{
     uapi, Access, AddRuleError, AddRulesError, CompatError, CompatLevel, CompatResult, CompatState,
-    Compatible, HandleAccessError, HandleAccessesError, PrivateHandledAccess, PrivateRule, Rule,
-    Ruleset, RulesetCreated, TailoredCompatLevel, TryCompat, ABI,
+    Compatible, HandleAccessError, HandleAccessesError, HandledAccess, PrivateHandledAccess,
+    PrivateRule, Rule, Ruleset, RulesetCreated, TailoredCompatLevel, TryCompat, ABI,
 };
 use enumflags2::{bitflags, BitFlags};
 use std::mem::zeroed;
@@ -59,6 +59,8 @@ impl Access for AccessNet {
         }
     }
 }
+
+impl HandledAccess for AccessNet {}
 
 impl PrivateHandledAccess for AccessNet {
     fn ruleset_handle_access(


### PR DESCRIPTION
With a generic HandledAccess implementation for all PrivateHandledAccess implementations, the documentations does not show the actual types. Make these implementation explicit to improve the documentation.

See #99