### PR TITLE
Print hints about Landlock ABI version

### DIFF
--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -5,8 +5,8 @@
 
 use anyhow::{anyhow, bail, Context};
 use landlock::{
-    path_beneath_rules, Access, AccessFs, AccessNet, BitFlags, NetPort, PathBeneath, PathFd,
-    Ruleset, RulesetAttr, RulesetCreatedAttr, RulesetStatus, Scope, ABI,
+    path_beneath_rules, Access, AccessFs, AccessNet, BitFlags, LandlockStatus, NetPort,
+    PathBeneath, PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr, RulesetStatus, Scope, ABI,
 };
 use std::env;
 use std::ffi::OsStr;
@@ -168,8 +168,22 @@ fn main() -> anyhow::Result<()> {
         .restrict_self()
         .expect("Failed to enforce ruleset");
 
+    match status.landlock {
+        // This should never happen because of the previous check:
+        LandlockStatus::NotEnabled => eprintln!("Landlock is not enabled in the running kernel"),
+        LandlockStatus::NotImplemented => {
+            eprintln!("Landlock is not implemented in the running kernel")
+        }
+        LandlockStatus::Available(current_abi) => {
+            if current_abi > abi {
+                eprintln!("Hint: You should update this sandboxer to leverage Landlock features provided by ABI version {current_abi} (instead of {abi})");
+            } else if current_abi < abi {
+                eprintln!("Hint: You should update the running kernel to leverage Landlock features provided by ABI version {abi} (instead of {current_abi})");
+            }
+        }
+    }
     if status.ruleset == RulesetStatus::NotEnforced {
-        bail!("Landlock is not supported by the running kernel.");
+        bail!("The ruleset cannot be enforced at all");
     }
 
     eprintln!("Executing the sandboxed command...");

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::{uapi, Access, CompatError};
+use std::fmt::{self, Display, Formatter};
 
 #[cfg(test)]
 use std::convert::TryInto;
@@ -41,11 +42,8 @@ use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 ///
 /// In a nutshell, test the access rights you request on a kernel that support them and
 /// on a kernel that doesn't support them.
-#[cfg_attr(
-    test,
-    derive(Debug, PartialEq, Eq, PartialOrd, EnumIter, EnumCountMacro)
-)]
-#[derive(Copy, Clone)]
+#[cfg_attr(test, derive(EnumIter, EnumCountMacro))]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum ABI {
     /// Kernel not supporting Landlock, either because it is not built with Landlock
@@ -71,17 +69,17 @@ pub enum ABI {
     V6 = 6,
 }
 
+// ABI should not be dynamically created (in other crates) according to the running kernel
+// to avoid inconsistent behaviors and non-determinism. Creating ABIs based on runtime detection
+// can lead to unreliable sandboxing where rules might differ between executions.
 impl ABI {
-    // Must remain private to avoid inconsistent behavior by passing Ok(self) to a builder method,
-    // e.g. to make it impossible to call ruleset.handle_fs(ABI::new_current()?)
+    // Must remain private to avoid inconsistent behavior using such unknown-at-build-time ABI
+    // e.g., AccessFs::from_all(ABI::new_current())
     fn new_current() -> Self {
-        ABI::from(unsafe {
-            // Landlock ABI version starts at 1 but errno is only set for negative values.
-            uapi::landlock_create_ruleset(
-                std::ptr::null(),
-                0,
-                uapi::LANDLOCK_CREATE_RULESET_VERSION,
-            )
+        // Interprets all kind of errors as unsupported.
+        ABI::from(match LandlockStatus::current() {
+            LandlockStatus::Available(abi) => abi.0 as i32,
+            _ => -1,
         })
     }
 
@@ -97,8 +95,6 @@ impl ABI {
 impl From<i32> for ABI {
     fn from(value: i32) -> ABI {
         match value {
-            // The only possible error values should be EOPNOTSUPP and ENOSYS, but let's interpret
-            // all kind of errors as unsupported.
             n if n <= 0 => ABI::Unsupported,
             1 => ABI::V1,
             2 => ABI::V2,
@@ -127,14 +123,14 @@ fn abi_from() {
     }
 
     assert_eq!(ABI::from(last_i + 1), last_abi);
-    assert_eq!(ABI::from(9), last_abi);
+    assert_eq!(ABI::from(999), last_abi);
 }
 
 #[test]
 fn known_abi() {
     assert!(!ABI::is_known(-1));
     assert!(!ABI::is_known(0));
-    assert!(!ABI::is_known(99));
+    assert!(!ABI::is_known(999));
 
     let mut last_i = -1;
     for (i, _) in ABI::iter().enumerate().skip(1) {
@@ -142,6 +138,132 @@ fn known_abi() {
         assert!(ABI::is_known(last_i));
     }
     assert!(!ABI::is_known(last_i + 1));
+}
+
+impl Display for ABI {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ABI::Unsupported => write!(f, "Unsupported"),
+            v => (*v as u32).fmt(f),
+        }
+    }
+}
+
+/// Status of Landlock support for the running system.
+///
+/// This enum is used to represent the status of the Landlock support for the system where the code
+/// is executed. It can indicate whether Landlock is available or not.
+///
+/// # Warning
+///
+/// Sandboxed programs should only use this data to log or provide optional information to users,
+/// not to change their behavior according to this status.  Indeed, the `Ruleset` and the other
+/// types are designed to handle the compatibility in a simple and safe way.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum LandlockStatus {
+    /// Landlock is supported but not enabled.
+    NotEnabled,
+    /// Landlock is not implemented in the running kernel.
+    NotImplemented,
+    /// Landlock is available with the given ABI.
+    Available(CurrentABI),
+}
+
+impl LandlockStatus {
+    // This should not be Default::default() because the returned value would may not be the same
+    // for all users.
+    fn current() -> Self {
+        // Landlock ABI version starts at 1 but errno is only set for negative values.
+        match unsafe {
+            uapi::landlock_create_ruleset(
+                std::ptr::null(),
+                0,
+                uapi::LANDLOCK_CREATE_RULESET_VERSION,
+            )
+        } {
+            v if v < 0 => {
+                // The only possible error values should be EOPNOTSUPP and ENOSYS.
+                if v == libc::EOPNOTSUPP {
+                    Self::NotEnabled
+                } else {
+                    Self::NotImplemented
+                }
+            }
+            v => Self::Available(CurrentABI(v as u32)),
+        }
+    }
+
+    // This is only useful to tests and should not be exposed publicly
+    // (e.g. not implemented as a From trait).
+    fn from_abi(abi: ABI) -> Self {
+        match abi {
+            ABI::Unsupported => Self::NotEnabled,
+            _ => Self::Available(CurrentABI(abi as u32)),
+        }
+    }
+}
+
+/// Represents the current Landlock ABI version.
+///
+/// `CurrentABI` reflects the Landlock ABI version of the running kernel.
+/// The current ABI version might not be known by this crate (i.e. `ABI`), which is why `CurrentABI`
+/// should only be used to diagnose issues or for testing.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+// The inner value must remain private to avoid inconsistent behavior using such unknown-at-build-time ABI
+// e.g., AccessFs::from_all(ABI::new_current())
+// We must not be able to (trivially) transform CurrentABI to ABI.
+pub struct CurrentABI(u32);
+
+impl CurrentABI {
+    #[cfg(test)]
+    pub(crate) fn new(abi: u32) -> Self {
+        Self(abi)
+    }
+}
+
+impl PartialEq<ABI> for CurrentABI {
+    fn eq(&self, other: &ABI) -> bool {
+        // Different than ABI::from(self.0 as i32).eq(other)
+        self.0.eq(&(*other as u32))
+    }
+}
+
+impl PartialOrd<ABI> for CurrentABI {
+    fn partial_cmp(&self, other: &ABI) -> Option<std::cmp::Ordering> {
+        // Different than ABI::from(self.0 as i32).partial_cmp(other)
+        self.0.partial_cmp(&(*other as u32))
+    }
+}
+
+impl Display for CurrentABI {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            0 => write!(f, "Unsupported"),
+            v => v.fmt(f),
+        }
+    }
+}
+
+#[test]
+fn current_abi_cmp() {
+    let unknown = CurrentABI(999);
+    assert_ne!(unknown, ABI::from(999));
+    assert!(unknown > ABI::from(999));
+
+    for (i, abi) in ABI::iter().enumerate() {
+        assert_ne!(unknown, abi);
+        assert!(unknown > abi);
+
+        let i = i.try_into().unwrap();
+        assert_eq!(CurrentABI(i), abi);
+        assert!(CurrentABI(i + 1) > abi);
+        if i > 0 {
+            assert!(CurrentABI(i - 1) < abi);
+        }
+
+        // Tests Display implementations.
+        assert_eq!(format!("{}", CurrentABI(i)), format!("{}", abi));
+    }
 }
 
 #[cfg(test)]
@@ -175,15 +297,21 @@ pub(crate) fn can_emulate(mock: ABI, partial_support: ABI, full_support: Option<
 pub(crate) fn get_errno_from_landlock_status() -> Option<i32> {
     use std::io::Error;
 
-    match ABI::new_current() {
-        ABI::Unsupported => match Error::last_os_error().raw_os_error() {
-            // Returns ENOSYS when the kernel is not built with Landlock support,
-            // or EOPNOTSUPP when Landlock is supported but disabled at boot time.
-            ret @ Some(libc::ENOSYS | libc::EOPNOTSUPP) => ret,
-            // Other values can only come from bogus seccomp filters or debug tampering.
-            _ => unreachable!(),
-        },
-        _ => None,
+    match LandlockStatus::current() {
+        LandlockStatus::NotImplemented | LandlockStatus::NotEnabled => {
+            match Error::last_os_error().raw_os_error() {
+                // Returns ENOSYS when the kernel is not built with Landlock support,
+                // or EOPNOTSUPP when Landlock is supported but disabled at boot time.
+                ret @ Some(libc::ENOSYS | libc::EOPNOTSUPP) => ret,
+                // Other values can only come from bogus seccomp filters or debugging tampering.
+                ret => {
+                    eprintln!("Current kernel should support this Landlock ABI according to $LANDLOCK_CRATE_TEST_ABI");
+                    eprintln!("Unexpected result: {ret:?}");
+                    unreachable!();
+                }
+            }
+        }
+        LandlockStatus::Available(_) => None,
     }
 }
 
@@ -279,18 +407,24 @@ fn compat_state_update_2() {
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[derive(Copy, Clone)]
 pub(crate) struct Compatibility {
-    abi: ABI,
+    status: LandlockStatus,
     pub(crate) level: Option<CompatLevel>,
     pub(crate) state: CompatState,
 }
 
-impl From<ABI> for Compatibility {
-    fn from(abi: ABI) -> Self {
+impl From<LandlockStatus> for Compatibility {
+    fn from(status: LandlockStatus) -> Self {
         Compatibility {
-            abi,
+            status,
             level: Default::default(),
             state: CompatState::Init,
         }
+    }
+}
+
+impl From<ABI> for Compatibility {
+    fn from(abi: ABI) -> Self {
+        Self::from(LandlockStatus::from_abi(abi))
     }
 }
 
@@ -306,7 +440,14 @@ impl Compatibility {
     }
 
     pub(crate) fn abi(&self) -> ABI {
-        self.abi
+        match self.status {
+            LandlockStatus::NotEnabled | LandlockStatus::NotImplemented => ABI::Unsupported,
+            LandlockStatus::Available(abi) => ABI::from(abi.0 as i32),
+        }
+    }
+
+    pub(crate) fn status(&self) -> LandlockStatus {
+        self.status
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 extern crate lazy_static;
 
 pub use access::{Access, HandledAccess};
-pub use compat::{CompatLevel, Compatible, ABI};
+pub use compat::{CompatLevel, Compatible, CurrentABI, LandlockStatus, ABI};
 pub use enumflags2::{make_bitflags, BitFlags};
 pub use errors::{
     AccessError, AddRuleError, AddRulesError, CompatError, CreateRulesetError, Errno,
@@ -166,13 +166,20 @@ mod tests {
                     } else {
                         RulesetStatus::NotEnforced
                     };
+                    let landlock_status = if abi == ABI::Unsupported {
+                        LandlockStatus::NotEnabled
+                    } else {
+                        LandlockStatus::Available(CurrentABI::new(abi as u32))
+                    };
                     println!("Expecting ruleset status {ruleset_status:?}");
+                    println!("Expecting Landlock status {landlock_status:?}");
                     assert!(matches!(
                         ret,
                         Ok(RestrictionStatus {
                             ruleset,
+                            landlock,
                             no_new_privs: true,
-                        }) if ruleset == ruleset_status
+                        }) if ruleset == ruleset_status && landlock == landlock_status
                     ))
                 }
             } else {

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -3,8 +3,8 @@
 use crate::compat::private::OptionCompatLevelMut;
 use crate::{
     uapi, AccessFs, AccessNet, AddRuleError, AddRulesError, BitFlags, CompatLevel, CompatState,
-    Compatibility, Compatible, CreateRulesetError, HandledAccess, PrivateHandledAccess,
-    RestrictSelfError, RulesetError, Scope, ScopeError, TryCompat,
+    Compatibility, Compatible, CreateRulesetError, HandledAccess, LandlockStatus,
+    PrivateHandledAccess, RestrictSelfError, RulesetError, Scope, ScopeError, TryCompat,
 };
 use libc::close;
 use std::io::Error;
@@ -72,6 +72,8 @@ pub struct RestrictionStatus {
     pub ruleset: RulesetStatus,
     /// Status of `prctl(2)`'s `PR_SET_NO_NEW_PRIVS` enforcement.
     pub no_new_privs: bool,
+    /// Status of Landlock for the running kernel.
+    pub landlock: LandlockStatus,
 }
 
 fn prctl_set_no_new_privs() -> Result<(), Error> {
@@ -790,6 +792,7 @@ impl RulesetCreated {
             match self.compat.state {
                 CompatState::Init | CompatState::No | CompatState::Dummy => Ok(RestrictionStatus {
                     ruleset: self.compat.state.into(),
+                    landlock: self.compat.status(),
                     no_new_privs: enforced_nnp,
                 }),
                 CompatState::Full | CompatState::Partial => {
@@ -798,6 +801,7 @@ impl RulesetCreated {
                             self.compat.update(CompatState::Full);
                             Ok(RestrictionStatus {
                                 ruleset: self.compat.state.into(),
+                                landlock: self.compat.status(),
                                 no_new_privs: enforced_nnp,
                             })
                         }
@@ -900,6 +904,7 @@ fn ruleset_created_attr() {
             .unwrap(),
         RestrictionStatus {
             ruleset: RulesetStatus::NotEnforced,
+            landlock: LandlockStatus::NotEnabled,
             no_new_privs: true,
         }
     );
@@ -973,6 +978,7 @@ fn ruleset_unsupported() {
             .unwrap(),
         RestrictionStatus {
             ruleset: RulesetStatus::NotEnforced,
+            landlock: LandlockStatus::NotEnabled,
             // With BestEffort, no_new_privs is still enabled.
             no_new_privs: true,
         }
@@ -990,6 +996,7 @@ fn ruleset_unsupported() {
             .unwrap(),
         RestrictionStatus {
             ruleset: RulesetStatus::NotEnforced,
+            landlock: LandlockStatus::NotEnabled,
             // With SoftRequirement, no_new_privs is still enabled.
             no_new_privs: true,
         }
@@ -1027,6 +1034,7 @@ fn ruleset_unsupported() {
             .unwrap(),
         RestrictionStatus {
             ruleset: RulesetStatus::NotEnforced,
+            landlock: LandlockStatus::NotEnabled,
             // With SoftRequirement, no_new_privs is untouched if there is no error (e.g. no rule).
             no_new_privs: true,
         }
@@ -1048,6 +1056,7 @@ fn ruleset_unsupported() {
                 .unwrap(),
             RestrictionStatus {
                 ruleset: RulesetStatus::NotEnforced,
+                landlock: LandlockStatus::Available(CurrentABI::new(1)),
                 // With SoftRequirement, no_new_privs is still enabled, even if there is an error
                 // (e.g. unsupported access right).
                 no_new_privs: true,
@@ -1066,6 +1075,7 @@ fn ruleset_unsupported() {
             .unwrap(),
         RestrictionStatus {
             ruleset: RulesetStatus::NotEnforced,
+            landlock: LandlockStatus::NotEnabled,
             no_new_privs: false,
         }
     );
@@ -1168,6 +1178,7 @@ fn ignore_abi_v2_with_abi_v1() {
             .unwrap(),
         RestrictionStatus {
             ruleset: RulesetStatus::NotEnforced,
+            landlock: LandlockStatus::Available(CurrentABI::new(1)),
             no_new_privs: true,
         }
     );


### PR DESCRIPTION
Add the LandlockStatus and CurrentABI:
- LandlockStatus can be used to query the running kernel and display information about the available Landlock features.
- CurrentABI can be used to compare to known ABI versions, but it cannot directly (and should not) be used for other purpose.

Export Debug, Eq, and Ord implementations for ABI, and implement Display for ABI and CurrentABI.

Replace ABI in Compatibility with LandlockStatus to be able to return this information with RestrictionStatus.

Update the sandboxer to print hints about the status of Landlock like for the C example.

Replace some ABI::new_current() calls with LandlockStatus::current().