### PR TITLE
Use OwnedFd instead of RawFd

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -318,7 +318,7 @@ fn path_beneath_try_compat_children() {
     // Do not actually perform any syscall.
     ruleset.compat.state = CompatState::Dummy;
     assert!(matches!(
-        RulesetCreated::new(ruleset, -1)
+        RulesetCreated::new(ruleset, None)
             .set_compatibility(CompatLevel::HardRequirement)
             .add_rule(PathBeneath::new(PathFd::new("/dev/null").unwrap(), access_file))
             .unwrap_err(),
@@ -332,7 +332,7 @@ fn path_beneath_try_compat_children() {
     // Do not actually perform any syscall.
     ruleset.compat.state = CompatState::Dummy;
     assert!(matches!(
-        RulesetCreated::new(ruleset, -1)
+        RulesetCreated::new(ruleset, None)
             .set_compatibility(CompatLevel::HardRequirement)
             .add_rule(PathBeneath::new(PathFd::new("/dev/null").unwrap(), access_file))
             .unwrap_err(),


### PR DESCRIPTION
Improve consistency by delegating lifetime management to OwnedFd.  The only visible change would be that with latest Rust versions, the duplicated file descriptor will be greater than 2 (not with Rust 1.63). See https://doc.rust-lang.org/1.63.0/std/os/unix/io/struct.OwnedFd.html

Remove the explicit RulesetCreated's Drop implementation which is now handled by its inner OwnedFd.

Replate IntoRawFd with the safer Into<Option<OwnedFd>> for RulesetCreated.  The former is implemented for OwnedFd.  This is not a breaking change because the IntoRawFd implementation was never released.

Add tests leveraging RulesetCreated::try_clone().

See #85 