### PR TITLE
Implement common traits for public types

### DIFF
--- a/src/compat.rs
+++ b/src/compat.rs
@@ -41,11 +41,10 @@ use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 ///
 /// In a nutshell, test the access rights you request on a kernel that support them and
 /// on a kernel that doesn't support them.
-#[cfg_attr(
-    test,
-    derive(Debug, PartialEq, Eq, PartialOrd, EnumIter, EnumCountMacro)
-)]
-#[derive(Copy, Clone)]
+///
+/// Derived `Debug` formats are [not stable](https://doc.rust-lang.org/stable/std/fmt/trait.Debug.html#stability).
+#[cfg_attr(test, derive(EnumIter, EnumCountMacro))]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum ABI {
     /// Kernel not supporting Landlock, either because it is not built with Landlock
@@ -208,8 +207,7 @@ fn current_kernel_abi() {
 
 // CompatState is not public outside this crate.
 /// Returned by ruleset builder.
-#[cfg_attr(test, derive(Debug))]
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CompatState {
     /// Initial undefined state.
     Init,
@@ -276,8 +274,8 @@ fn compat_state_update_2() {
     assert_eq!(state, CompatState::Partial);
 }
 
-#[cfg_attr(test, derive(Debug, PartialEq))]
-#[derive(Copy, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Copy, Clone, Debug)]
 pub(crate) struct Compatibility {
     abi: ABI,
     pub(crate) level: Option<CompatLevel>,

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -226,7 +226,7 @@ where
 ///     Ok(PathBeneath::new(PathFd::new("/home")?, AccessFs::ReadDir))
 /// }
 /// ```
-#[cfg_attr(test, derive(Debug))]
+#[derive(Debug)]
 pub struct PathBeneath<F> {
     attr: uapi::landlock_path_beneath_attr,
     // Ties the lifetime of a file descriptor to this object.
@@ -502,7 +502,7 @@ fn path_beneath_check_consistency() {
 ///     Ok(PathBeneath::new(fd, access))
 /// }
 /// ```
-#[cfg_attr(test, derive(Debug))]
+#[derive(Debug)]
 pub struct PathFd {
     fd: OwnedFd,
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -105,7 +105,7 @@ impl PrivateHandledAccess for AccessNet {
 ///     NetPort::new(80, AccessNet::BindTcp)
 /// }
 /// ```
-#[cfg_attr(test, derive(Debug))]
+#[derive(Debug)]
 pub struct NetPort {
     attr: uapi::landlock_net_port_attr,
     // Only 16-bit port make sense for now.

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -170,7 +170,7 @@ fn support_no_new_privs() -> bool {
 ///
 /// let status = restrict_paths(&["/usr", "/home"]).expect("failed to build the ruleset");
 /// ```
-#[cfg_attr(test, derive(Debug))]
+#[derive(Debug)]
 pub struct Ruleset {
     pub(crate) requested_handled_fs: BitFlags<AccessFs>,
     pub(crate) requested_handled_net: BitFlags<AccessNet>,
@@ -720,7 +720,7 @@ pub trait RulesetCreatedAttr: Sized + AsMut<RulesetCreated> + Compatible {
 }
 
 /// Ruleset created with [`Ruleset::create()`].
-#[cfg_attr(test, derive(Debug))]
+#[derive(Debug)]
 pub struct RulesetCreated {
     fd: Option<OwnedFd>,
     no_new_privs: bool,


### PR DESCRIPTION
Implement Debug for ABI, Ruleset, RulesetCreated, PathBeneath, PathFd, and NetPort (and other non-public dependencies).  Derived Debug formats are not stable:
https://doc.rust-lang.org/stable/std/fmt/trait.Debug.html#stability

Implement PartialEq, Eq, PartialOrd, and Ord for ABI.

This might be needed when these types are wrapped (see LandlockConfig).

See https://github.com/landlock-lsm/rust-landlock/issues/82