### PR TITLE
Bump dependencies and add SoftRequirement test for scope()

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,8 +113,6 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-    env:
-      LANDLOCK_CRATE_TEST_ABI: 5
     steps:
 
     - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "landlock"
 version = "0.4.4"
 edition = "2021"
-rust-version = "1.68"
+rust-version = "1.71"
 description = "Landlock LSM helpers"
 homepage = "https://landlock.io"
 repository = "https://github.com/landlock-lsm/rust-landlock"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! This crate provides a safe abstraction for the Landlock system calls, along with some helpers.
 //!
-//! Minimum Supported Rust Version (MSRV): 1.68
+//! Minimum Supported Rust Version (MSRV): 1.71
 //!
 //! # Use cases
 //!

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -1135,6 +1135,16 @@ fn ruleset_unsupported() {
         RulesetError::Scope(ScopeError::Compat(CompatError::Access(AccessError::Empty)))
     ));
 
+    // Scope with SoftRequirement on unsupported ABI: silently dropped, state becomes Dummy.
+    let ruleset = Ruleset::from(ABI::V1)
+        .handle_access(AccessFs::Execute)
+        .unwrap()
+        .set_compatibility(CompatLevel::SoftRequirement)
+        .scope(Scope::Signal)
+        .unwrap();
+    assert_eq!(ruleset.requested_scoped, BitFlags::from(Scope::Signal));
+    assert_eq!(ruleset.actual_scoped, BitFlags::<Scope>::EMPTY);
+
     // Tests inconsistency between the ruleset handled access-rights and the rule access-rights.
     for handled_access in &[
         make_bitflags!(AccessFs::{Execute | WriteFile}),


### PR DESCRIPTION
Add a missing test case for scope() with SoftRequirement on an unsupported ABI.  Verifies the flag is silently dropped and the compat state transitions to Dummy.

This complements the existing BestEffort and HardRequirement tests.