### PR TITLE
Rename set_no_new_privs() to no_new_privs()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ mod errata;
 mod errors;
 mod fs;
 mod net;
+mod prctl;
 mod ruleset;
 mod scope;
 mod uapi;
@@ -300,7 +301,7 @@ mod tests {
                     .set_compatibility(CompatLevel::BestEffort)
                     .handle_access(AccessFs::from_all(abi))?
                     .create()?
-                    .set_no_new_privs(true)
+                    .no_new_privs(true)
                     .add_rule(PathBeneath::new(PathFd::new("/")?, AccessFs::from_all(abi)))?
                     .restrict_self()?)
             },

--- a/src/prctl.rs
+++ b/src/prctl.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! `prctl(2)` wrappers used by Landlock enforcement.
+//!
+//! These helpers are pub(crate) and called from
+//! [`RulesetCreated::restrict_self()`](crate::RulesetCreated::restrict_self).
+
+use crate::compat::Compatibility;
+use crate::{CompatLevel, CompatState, RestrictSelfError};
+use std::io::Error;
+
+fn prctl_set_no_new_privs() -> Result<(), Error> {
+    match unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } {
+        0 => Ok(()),
+        _ => Err(Error::last_os_error()),
+    }
+}
+
+fn support_no_new_privs() -> bool {
+    // Only Linux < 3.5 or kernel with seccomp filters should return an error.
+    matches!(
+        unsafe { libc::prctl(libc::PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) },
+        0 | 1
+    )
+}
+
+/// Calls `prctl(PR_SET_NO_NEW_PRIVS, 1)` and dispatches errors based on the
+/// current compatibility level.
+///
+/// Returns `Ok(true)` if `no_new_privs` was successfully enforced.  Returns
+/// `Ok(false)` if `prctl` failed but the failure was tolerated by the
+/// current [`CompatLevel`] (silently dropped under `BestEffort`, transitions
+/// to `Dummy` under `SoftRequirement`).  Returns `Err` if `prctl` failed
+/// under `HardRequirement`, or if the running kernel claims to support
+/// `no_new_privs` (or Landlock itself) but the call still failed.
+pub(crate) fn try_set_no_new_privs(compat: &mut Compatibility) -> Result<bool, RestrictSelfError> {
+    if let Err(e) = prctl_set_no_new_privs() {
+        match compat.level.into() {
+            CompatLevel::BestEffort => {}
+            CompatLevel::SoftRequirement => {
+                compat.update(CompatState::Dummy);
+            }
+            CompatLevel::HardRequirement => {
+                return Err(RestrictSelfError::SetNoNewPrivsCall { source: e });
+            }
+        }
+        // To get a consistent behavior, calls this prctl whether or not
+        // Landlock is supported by the running kernel.
+        let support_nnp = support_no_new_privs();
+        match compat.state {
+            // It should not be an error for kernel (older than 3.5) not supporting
+            // no_new_privs.
+            CompatState::Init | CompatState::No | CompatState::Dummy => {
+                if support_nnp {
+                    // The kernel seems to be between 3.5 (included) and 5.13 (excluded),
+                    // or Landlock is not enabled; no_new_privs should be supported anyway.
+                    return Err(RestrictSelfError::SetNoNewPrivsCall { source: e });
+                }
+            }
+            // A kernel supporting Landlock should also support no_new_privs (unless
+            // filtered by seccomp).
+            CompatState::Full | CompatState::Partial => {
+                return Err(RestrictSelfError::SetNoNewPrivsCall { source: e })
+            }
+        }
+        Ok(false)
+    } else {
+        Ok(true)
+    }
+}

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::compat::private::OptionCompatLevelMut;
+use crate::prctl::try_set_no_new_privs;
 use crate::{
     uapi, AccessFs, AccessNet, AddRuleError, AddRulesError, BitFlags, CompatLevel, CompatState,
     Compatibility, Compatible, CreateRulesetError, HandledAccess, LandlockStatus,
@@ -73,21 +74,6 @@ pub struct RestrictionStatus {
     pub no_new_privs: bool,
     /// Status of Landlock for the running kernel.
     pub landlock: LandlockStatus,
-}
-
-fn prctl_set_no_new_privs() -> Result<(), Error> {
-    match unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } {
-        0 => Ok(()),
-        _ => Err(Error::last_os_error()),
-    }
-}
-
-fn support_no_new_privs() -> bool {
-    // Only Linux < 3.5 or kernel with seccomp filters should return an error.
-    matches!(
-        unsafe { libc::prctl(libc::PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) },
-        0 | 1
-    )
 }
 
 /// Landlock ruleset builder.
@@ -715,9 +701,15 @@ pub trait RulesetCreatedAttr: Sized + AsMut<RulesetCreated> + Compatible {
     ///
     /// This `prctl(2)` call is never ignored, even if an error was encountered on a [`Ruleset`] or
     /// [`RulesetCreated`] method call while [`CompatLevel::SoftRequirement`] was set.
-    fn set_no_new_privs(mut self, no_new_privs: bool) -> Self {
-        <Self as AsMut<RulesetCreated>>::as_mut(&mut self).no_new_privs = no_new_privs;
+    fn no_new_privs(mut self, yes: bool) -> Self {
+        <Self as AsMut<RulesetCreated>>::as_mut(&mut self).no_new_privs = yes;
         self
+    }
+
+    /// Alias for [`no_new_privs()`](Self::no_new_privs).
+    #[deprecated(note = "Use no_new_privs() instead.")]
+    fn set_no_new_privs(self, yes: bool) -> Self {
+        self.no_new_privs(yes)
     }
 }
 
@@ -759,39 +751,7 @@ impl RulesetCreated {
             // that no_new_privs should not be an issue on its own if it is not explicitly
             // deactivated.
             let enforced_nnp = if self.no_new_privs {
-                if let Err(e) = prctl_set_no_new_privs() {
-                    match self.compat.level.into() {
-                        CompatLevel::BestEffort => {}
-                        CompatLevel::SoftRequirement => {
-                            self.compat.update(CompatState::Dummy);
-                        }
-                        CompatLevel::HardRequirement => {
-                            return Err(RestrictSelfError::SetNoNewPrivsCall { source: e });
-                        }
-                    }
-                    // To get a consistent behavior, calls this prctl whether or not
-                    // Landlock is supported by the running kernel.
-                    let support_nnp = support_no_new_privs();
-                    match self.compat.state {
-                        // It should not be an error for kernel (older than 3.5) not supporting
-                        // no_new_privs.
-                        CompatState::Init | CompatState::No | CompatState::Dummy => {
-                            if support_nnp {
-                                // The kernel seems to be between 3.5 (included) and 5.13 (excluded),
-                                // or Landlock is not enabled; no_new_privs should be supported anyway.
-                                return Err(RestrictSelfError::SetNoNewPrivsCall { source: e });
-                            }
-                        }
-                        // A kernel supporting Landlock should also support no_new_privs (unless
-                        // filtered by seccomp).
-                        CompatState::Full | CompatState::Partial => {
-                            return Err(RestrictSelfError::SetNoNewPrivsCall { source: e })
-                        }
-                    }
-                    false
-                } else {
-                    true
-                }
+                try_set_no_new_privs(&mut self.compat)?
             } else {
                 false
             };
@@ -1079,7 +1039,7 @@ fn ruleset_unsupported() {
             .unwrap()
             .create()
             .unwrap()
-            .set_no_new_privs(false)
+            .no_new_privs(false)
             .restrict_self()
             .unwrap(),
         RestrictionStatus {


### PR DESCRIPTION
The Rust builder pattern is meant to read as a declarative list of configurations rather than a sequence of imperative commands, see https://rust-lang.github.io/api-guidelines/type-safety.html?#builders-enable-construction-of-complex-values-c-builder https://rust-lang.github.io/rfcs/0344-conventions-galore.html#gettersetter-apis

Dropping `set_` from boolean field setters reduces boilerplate and makes the chain read uniformly (with upcomming log_* setters):

    Ruleset::default()
        .handle_access(...)?
        .create()?
        .log_same_exec(false)?
        .log_new_exec(true)?
        .log_subdomains(false)?
        .no_new_privs(false)
        .restrict_self()?;

Note that this method should only be rarely called because of the default value.

Verb-led method names are reserved for distinct actions beyond field assignment (handle_access, add_rule, restrict_self).

Keep set_no_new_privs as a #[deprecated] thin wrapper calling no_new_privs() to preserve backward compatibility.

set_compatibility() is out of scope for for now, see https://github.com/landlock-lsm/rust-landlock/pull/58